### PR TITLE
fix: correct generator command and templates

### DIFF
--- a/cli/hero.v
+++ b/cli/hero.v
@@ -88,7 +88,7 @@ fn do() ! {
 	// herocmds.cmd_caddy(mut cmd)
 	// herocmds.cmd_zola(mut cmd)
 	// herocmds.cmd_juggler(mut cmd)
-	// herocmds.cmd_generator(mut cmd)
+	herocmds.cmd_generator(mut cmd)
 	// herocmds.cmd_docsorter(mut cmd)
 	// cmd.add_command(publishing.cmd_publisher(pre_func))
 	cmd.setup()

--- a/lib/core/generator/generic/templates/objname_factory_.vtemplate
+++ b/lib/core/generator/generic/templates/objname_factory_.vtemplate
@@ -115,9 +115,8 @@ pub fn play(args_ PlayArgs) ! {
     if install_actions.len > 0 {
         for install_action in install_actions {
             mut p := install_action.params
-            mycfg:=cfg_play(p)!
+            cfg_play(p)!
             console.print_debug("install action ${args.name}.configure\n??{mycfg}")
-            set(mycfg)!
         }
     }
     @end

--- a/lib/core/generator/generic/templates/objname_model.vtemplate
+++ b/lib/core/generator/generic/templates/objname_model.vtemplate
@@ -44,7 +44,7 @@ pub fn heroscript_default() !string {
 
 //THIS THE THE SOURCE OF THE INFORMATION OF THIS FILE, HERE WE HAVE THE CONFIG OBJECT CONFIGURED AND MODELLED
 @if args.cat == .installer
-@[heap]
+^^[heap]
 pub struct ${args.classname} {
 pub mut:
     name string = 'default'
@@ -83,7 +83,7 @@ fn cfg_play(p paramsparser.Params) !${args.classname} {
 
 @else
 
-@[heap]
+^^[heap]
 pub struct ${args.classname} {
 pub mut:
     name string = 'default'

--- a/lib/core/herocmds/generator.v
+++ b/lib/core/herocmds/generator.v
@@ -21,7 +21,7 @@ pub fn cmd_generator(mut cmdroot Command) {
 	})
 
 	cmd_run.add_flag(Flag{
-		flag:        .bool
+		flag:        .string
 		required:    false
 		name:        'path'
 		abbrev:      'p'


### PR DESCRIPTION
- Correct the `generator` command to use a string flag for the path.
- Update templates to use correct heap allocation annotation.
- Remove unnecessary code in templates.