### PR TITLE
Update griddriver to use prebuilt binary

### DIFF
--- a/lib/installers/threefold/griddriver/griddriver_actions.v
+++ b/lib/installers/threefold/griddriver/griddriver_actions.v
@@ -1,15 +1,15 @@
 module griddriver
 
+import freeflowuniverse.herolib.osal
 import freeflowuniverse.herolib.ui.console
+import freeflowuniverse.herolib.core
 import freeflowuniverse.herolib.core.texttools
 import freeflowuniverse.herolib.installers.ulist
-import freeflowuniverse.herolib.installers.lang.golang
-import freeflowuniverse.herolib.develop.gittools
 import os
 
 // checks if a certain version or above is installed
 fn installed() !bool {
-	res := os.execute('/bin/bash -c "griddriver --version"')
+	res := os.execute('griddriver --version')
 	if res.exit_code != 0 {
 		return false
 	}
@@ -36,45 +36,36 @@ fn ulist_get() !ulist.UList {
 fn upload() ! {}
 
 fn install() ! {
-	console.print_header('install griddriver')
-	build()!
-	console.print_header('install griddriver OK')
-}
-
-fn build() ! {
-	console.print_header('build griddriver')
-	mut installer := golang.get()!
-	installer.install()!
-
-	mut gs := gittools.get()!
-	url := 'https://github.com/threefoldtech/web3gw/tree/development_integration/griddriver'
-
-	mut repo := gs.get_repo(
-		url:   url
-		reset: true
-		pull:  true
-	)!
-
-	mut path := repo.path()
-	path = '${path}/griddriver'
-
-	cmd := '/bin/bash -c "cd ${path} && . ${path}/build.sh"'
-	res := os.execute(cmd)
-	if res.exit_code != 0 {
-		return error('failed to build: ${res.output}')
+	console.print_header('installing griddriver')
+	mut url := ''
+	if core.is_linux_arm()! {
+		url = 'https://github.com/threefoldtech/griddriver/releases/download/v${version}/griddriver_${version}_linux_arm64'
+	} else if core.is_linux_intel()! {
+		url = 'https://github.com/threefoldtech/griddriver/releases/download/v${version}/griddriver_${version}_linux_amd64'
+	} else if core.is_osx_arm()! {
+		url = 'https://github.com/threefoldtech/griddriver/releases/download/v${version}/griddriver_${version}_darwin_arm64'
+	} else if core.is_osx_intel()! {
+		url = 'https://github.com/threefoldtech/griddriver/releases/download/v${version}/griddriver_${version}_darwin_amd64'
+	} else {
+		return error('unsported platform')
 	}
 
-	console.print_header('build griddriver OK')
+	mut dest := osal.download(
+		url:        url
+		minsize_kb: 1000
+	)!
+
+	osal.cmd_add(
+		cmdname: 'griddriver'
+		source:  dest.path
+	)!
+	console.print_header('install griddriver OK')
 }
 
 fn destroy() ! {
 	console.print_header('uninstall griddriver')
-	mut res := os.execute('sudo rm -rf /usr/local/bin/griddriver')
-	if res.exit_code != 0 {
-		return error('failed to uninstall griddriver: ${res.output}')
-	}
-
-	res = os.execute('sudo rm -rf ~/code/github/threefoldtech/web3gw')
+	binpath := osal.bin_path()!
+	mut res := os.execute('sudo rm -rf ${binpath}/griddriver')
 	if res.exit_code != 0 {
 		return error('failed to uninstall griddriver: ${res.output}')
 	}

--- a/lib/installers/threefold/griddriver/griddriver_factory_.v
+++ b/lib/installers/threefold/griddriver/griddriver_factory_.v
@@ -91,11 +91,6 @@ pub fn (mut self GridDriverInstaller) install(args InstallArgs) ! {
 	}
 }
 
-pub fn (mut self GridDriverInstaller) build() ! {
-	switch(self.name)
-	build()!
-}
-
 pub fn (mut self GridDriverInstaller) destroy() ! {
 	switch(self.name)
 	destroy()!

--- a/lib/installers/threefold/griddriver/griddriver_model.v
+++ b/lib/installers/threefold/griddriver/griddriver_model.v
@@ -2,7 +2,7 @@ module griddriver
 
 import freeflowuniverse.herolib.data.encoderhero
 
-pub const version = '0.1.1'
+pub const version = '0.1.2'
 const singleton = true
 const default = true
 

--- a/lib/installers/threefold/griddriver/readme.md
+++ b/lib/installers/threefold/griddriver/readme.md
@@ -1,26 +1,17 @@
 # griddriver
 
-
-
-To get started
+To use the installer:
 
 ```vlang
+import freeflowuniverse.herolib.installers.threefold.griddriver
 
-
-
-import freeflowuniverse.herolib.installers.something. griddriver
-
-mut installer:= griddriver.get()!
-
-installer.start()!
-
-
-
-
+fn main() {
+	mut installer := griddriver.get()!
+	installer.install()!
+}
 ```
 
 ## example heroscript
-
 
 ```hero
 !!griddriver.install
@@ -32,5 +23,3 @@ installer.start()!
     port: 8888
 
 ```
-
-


### PR DESCRIPTION
Updates the griddriver installer to use prebuilt binaries from the new dedicated repo (eg: https://github.com/threefoldtech/griddriver/releases/tag/v0.1.2).