### PR TITLE
Get mail VFS component to work

### DIFF
--- a/lib/vfs/vfs_local/model_fsentry.v
+++ b/lib/vfs/vfs_local/model_fsentry.v
@@ -1,6 +1,5 @@
 module vfs_local
 
-import os
 import freeflowuniverse.herolib.vfs
 
 // LocalFSEntry implements FSEntry for local filesystem

--- a/lib/vfs/vfs_mail/vfs_implementation_test.v
+++ b/lib/vfs/vfs_mail/vfs_implementation_test.v
@@ -1,15 +1,16 @@
 module vfs_mail
 
 import freeflowuniverse.herolib.vfs
-import freeflowuniverse.herolib.circles.models
-import freeflowuniverse.herolib.circles.models.mcc.mail
-import freeflowuniverse.herolib.circles.dbs.core
+// import freeflowuniverse.herolib.circles.mcc.models
+import freeflowuniverse.herolib.circles.mcc.models as mail
+import freeflowuniverse.herolib.circles.mcc.db as core
+import freeflowuniverse.herolib.circles.base
 import json
 import time
 
 fn test_mail_vfs() {
 	// Create a session state
-	mut session_state := models.new_session(name: 'test')!
+	mut session_state := base.new_session(name: 'test')!
 
 	// Create a mail database
 	mut mail_db := core.new_maildb(session_state)!


### PR DESCRIPTION
### Changes

- Removed unused `os` import from `model_fsentry.v`. 
- Updated `vfs_implementation_test.v` to use the correct import paths for mail-related modules.

### Related issues

- https://github.com/freeflowuniverse/herolib/issues/83
- https://github.com/freeflowuniverse/herolib/issues/87
