### PR TITLE
Rework playbook include and site import logic

### DIFF
--- a/examples/web/docusaurus_example.vsh
+++ b/examples/web/docusaurus_example.vsh
@@ -11,15 +11,15 @@ playcmds.run(
 		// install: 1
 		// template_update: 1
 
-	!!docusaurus.add sitename:"tfgrid_tech"
-		git_url:"https://git.threefold.info/tfgrid/docs_tfgrid4/src/branch/main/ebooks/tech"
+	!!docusaurus.add sitename:"owh_intro"
+		git_url:"https://git.ourworld.tf/ourworld_holding/docs_owh/src/branch/main/ebooks/owh_intro"
 		git_root:"/tmp/code"
 		git_reset:1
 		git_pull:1
 		play:true
 
-	!!docusaurus.build
+	// !!docusaurus.build
 
-	// !!docusaurus.dev site:"tfgrid_tech" open:true 
+	!!docusaurus.dev site:"owh_intro" open:true
 '
 )!


### PR DESCRIPTION
### Changes

- Replace manual script concatenation with playbook include handling
- Preserve site configuration (imports, menu) during generation
- Add support for copying static files from imported content
- Handle static assets from sibling `ebooksall` directories
- Fix the import copy logic not delete the destination before copying