### PR TITLE
test: update ping call parameters in tests

### DIFF
--- a/lib/data/ipaddress/ipaddress_test.v
+++ b/lib/data/ipaddress/ipaddress_test.v
@@ -25,7 +25,7 @@ fn test_ping() {
 	mut addr := IPAddress{
 		addr: '127.0.0.1'
 	}
-	assert addr.ping(timeout: 3)!
+	assert addr.ping(nr_ok: 3)!
 	assert addr.port == 0
 }
 
@@ -33,7 +33,7 @@ fn test_ping_fails() {
 	mut addr := IPAddress{
 		addr: '22.22.22.22'
 	}
-	assert addr.ping(timeout: 3)! == false
+	assert addr.ping(nr_ok: 3)! == false
 	assert addr.port == 0
 	assert addr.addr == '22.22.22.22'
 }
@@ -56,7 +56,7 @@ fn test_ipv6() {
 	mut addr := new('202:6a34:cd78:b0d7:5521:8de7:218e:6680') or { panic(err) }
 	assert addr.cat == .ipv6
 	assert addr.port == 0
-	// assert addr.ping(timeout: 3)! == false
+	// assert addr.ping(nr_ok: 3)! == false
 }
 
 fn test_ipv6b() {

--- a/lib/osal/core/net_test.v
+++ b/lib/osal/core/net_test.v
@@ -6,16 +6,16 @@ fn test_ipaddr_pub_get() {
 }
 
 fn test_ping() {
-	x := ping(address: '127.0.0.1', count: 1)!
+	x := ping(address: '127.0.0.1', retry: 1)!
 	assert x == .ok
 }
 
 fn test_ping_timeout() ! {
-	x := ping(address: '192.168.145.154', count: 5, timeout: 1)!
+	x := ping(address: '192.168.145.154', retry: 5, nr_ok: 1)!
 	assert x == .timeout
 }
 
 fn test_ping_unknownhost() ! {
-	x := ping(address: '12.902.219.1', count: 1, timeout: 1)!
+	x := ping(address: '12.902.219.1', retry: 1, nr_ok: 1)!
 	assert x == .unknownhost
 }


### PR DESCRIPTION
- Rename `timeout` to `nr_ok` in `addr.ping` calls
- Rename `count` to `retry` in `ping` function calls
- Replace `timeout` with `nr_ok` in `ping` function calls