### PR TITLE
fix: Zinit client error when creating service

### DIFF
--- a/lib/core/generator/generic/model_meta.v
+++ b/lib/core/generator/generic/model_meta.v
@@ -113,7 +113,11 @@ fn (mut m ModuleMeta) check() ! {
 	}
 	mut module_path := m.path.replace('/', '.')
 	if module_path.contains('incubaid.herolib.lib.') {
+		// Path is inside lib/ directory (e.g., lib/installers/horus/coordinator)
 		module_path = module_path.split('incubaid.herolib.lib.')[1]
+	} else if module_path.contains('incubaid.herolib.') {
+		// Path is directly under herolib root (e.g., zeko)
+		module_path = module_path.split('incubaid.herolib.')[1]
 	} else {
 		return error('path should be inside incubaid.herolib, so that module_path can be determined, now is: ${m.path}')
 	}

--- a/lib/core/generator/generic/templates/objname_actions.vtemplate
+++ b/lib/core/generator/generic/templates/objname_actions.vtemplate
@@ -20,19 +20,29 @@ import incubaid.herolib.installers.lang.python
 import os
 
 @if args.startupmanager
-fn (self &${args.classname}) startupcmd() ![]startupmanager.ZProcessNewArgs {
+^^[params]
+pub struct StartArgs {
+pub mut:
+	reset bool
+}
+
+fn (self &${args.classname}) startupcmd(args StartArgs) ![]startupmanager.ZProcessNewArgs {
 	mut res := []startupmanager.ZProcessNewArgs{}
+
+	reset := args.reset
+
 	//THIS IS EXAMPLE CODEAND NEEDS TO BE CHANGED
 	// res << startupmanager.ZProcessNewArgs{
 	// 	name: '${args.name}'
 	// 	cmd: '${args.name} server'
+	//  reset: reset
 	// 	env: {
 	// 		'HOME': '/root'
-	// 	}	
+	// 	}
 	// }
 
 	return res
-	
+
 }
 
 fn (self &${args.classname}) running_check() !bool {
@@ -57,21 +67,20 @@ fn (self &${args.classname}) running_check() !bool {
 }
 
 fn (self &${args.classname}) start_pre() ! {
-	
+
 }
 
 fn (self &${args.classname}) start_post() ! {
-	
+
 }
 
 fn (self &${args.classname}) stop_pre() ! {
-	
+
 }
 
 fn (self &${args.classname}) stop_post() ! {
-	
-}
 
+}
 @end
 
 //////////////////// following actions are not specific to instance of the object

--- a/lib/core/generator/generic/templates/objname_factory_.vtemplate
+++ b/lib/core/generator/generic/templates/objname_factory_.vtemplate
@@ -195,7 +195,7 @@ pub fn play(mut plbook PlayBook) ! {
             @if args.startupmanager
             if other_action.name == "start"{
                 console.print_debug("install action ${args.name}.??{other_action.name}")
-                ${args.name}_obj.start()!
+                ${args.name}_obj.start(reset: reset)!
             }
             if other_action.name == "stop"{
                 console.print_debug("install action ${args.name}.??{other_action.name}")
@@ -203,7 +203,7 @@ pub fn play(mut plbook PlayBook) ! {
             }
             if other_action.name == "restart"{
                 console.print_debug("install action ${args.name}.??{other_action.name}")
-                ${args.name}_obj.restart()!
+                ${args.name}_obj.restart(reset: reset)!
             }
             if other_action.name == "start_pre"{
                 console.print_debug("install action ${args.name}.??{other_action.name}")
@@ -273,10 +273,11 @@ pub fn (mut self ${args.classname}) reload() ! {
 @end
 
 @if args.startupmanager
-pub fn (mut self ${args.classname}) start() ! {
+pub fn (mut self ${args.classname}) start(args StartArgs) ! {
     @if ! args.singleton
     switch(self.name)
     @end
+
     if self.running()!{
         return
     }
@@ -289,7 +290,7 @@ pub fn (mut self ${args.classname}) start() ! {
 
     self.start_pre()!
 
-    for zprocess in self.startupcmd()!{
+    for zprocess in self.startupcmd(args)!{
         mut sm:=startupmanager_get(zprocess.startuptype)!
 
         console.print_debug('installer: ${args.name} starting with ??{zprocess.startuptype}...')
@@ -314,7 +315,7 @@ pub fn (mut self ${args.classname}) start() ! {
 pub fn (mut self ${args.classname}) install_start(args InstallArgs) ! {
     switch(self.name)
     self.install(args)!
-    self.start()!
+    self.start(reset: false)!
 }
 
 pub fn (mut self ${args.classname}) stop() ! {
@@ -327,10 +328,10 @@ pub fn (mut self ${args.classname}) stop() ! {
     self.stop_post()!
 }
 
-pub fn (mut self ${args.classname}) restart() ! {
+pub fn (mut self ${args.classname}) restart(args StartArgs) ! {
     switch(self.name)
     self.stop()!
-    self.start()!
+    self.start(args)!
 }
 
 pub fn (mut self ${args.classname}) running() !bool {

--- a/lib/core/herocmds/generator.v
+++ b/lib/core/herocmds/generator.v
@@ -71,12 +71,20 @@ fn cmd_generator_execute(cmd Command) ! {
 	// Handle "." as current working directory
 	if path == '.' {
 		path = os.getwd()
-	} else {
+	} else if path != '' {
 		// Expand home directory
 		path = path.replace('~', os.home_dir())
 
+		// Convert relative paths to absolute paths
+		if !os.is_abs_path(path) {
+			path = os.join_path(os.getwd(), path)
+		}
+
+		// Resolve to real path (handles symlinks and normalizes path)
+		path = os.real_path(path)
+
 		// Validate that path exists
-		if path != '' && !os.exists(path) {
+		if !os.exists(path) {
 			return error('Path does not exist: ${path}')
 		}
 	}

--- a/lib/installers/horus/coordinator/coordinator_actions.v
+++ b/lib/installers/horus/coordinator/coordinator_actions.v
@@ -9,13 +9,22 @@ import incubaid.herolib.installers.lang.rust
 import incubaid.herolib.develop.gittools
 import os
 
-fn (self &Coordinator) startupcmd() ![]startupmanager.ZProcessNewArgs {
+@[params]
+pub struct StartArgs {
+pub mut:
+	reset bool
+}
+
+fn (self &Coordinator) startupcmd(args StartArgs) ![]startupmanager.ZProcessNewArgs {
 	mut res := []startupmanager.ZProcessNewArgs{}
 
+	reset := args.reset
+
 	res << startupmanager.ZProcessNewArgs{
-		name: 'coordinator'
-		cmd:  '${self.binary_path} --redis-addr ${self.redis_addr} --api-http-port ${self.http_port} --api-ws-port ${self.ws_port}'
-		env:  {
+		name:  'coordinator'
+		cmd:   '${self.binary_path} --redis-addr ${self.redis_addr} --api-http-port ${self.http_port} --api-ws-port ${self.ws_port}'
+		reset: reset
+		env:   {
 			'HOME':           os.home_dir()
 			'RUST_LOG':       self.log_level
 			'RUST_LOG_STYLE': 'never'

--- a/lib/installers/horus/coordinator/coordinator_factory_.v
+++ b/lib/installers/horus/coordinator/coordinator_factory_.v
@@ -176,7 +176,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'start' {
 				console.print_debug('install action coordinator.${other_action.name}')
-				coordinator_obj.start()!
+				coordinator_obj.start(reset: reset)!
 			}
 			if other_action.name == 'stop' {
 				console.print_debug('install action coordinator.${other_action.name}')
@@ -184,7 +184,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'restart' {
 				console.print_debug('install action coordinator.${other_action.name}')
-				coordinator_obj.restart()!
+				coordinator_obj.restart(reset: reset)!
 			}
 			if other_action.name == 'start_pre' {
 				console.print_debug('install action coordinator.${other_action.name}')
@@ -244,7 +244,7 @@ pub fn (mut self Coordinator) reload() ! {
 	self = obj_init(self)!
 }
 
-pub fn (mut self Coordinator) start() ! {
+pub fn (mut self Coordinator) start(args StartArgs) ! {
 	switch(self.name)
 
 	if self.running()! {
@@ -260,7 +260,7 @@ pub fn (mut self Coordinator) start() ! {
 	self.configure()!
 
 	self.start_pre()!
-	for zprocess in self.startupcmd()! {
+	for zprocess in self.startupcmd(args)! {
 		mut sm := startupmanager_get(zprocess.startuptype)!
 
 		console.print_debug('installer: coordinator starting with ${zprocess.startuptype}...')
@@ -284,7 +284,7 @@ pub fn (mut self Coordinator) start() ! {
 pub fn (mut self Coordinator) install_start(args InstallArgs) ! {
 	switch(self.name)
 	self.install(args)!
-	self.start()!
+	self.start(reset: false)!
 }
 
 pub fn (mut self Coordinator) stop() ! {
@@ -297,10 +297,10 @@ pub fn (mut self Coordinator) stop() ! {
 	self.stop_post()!
 }
 
-pub fn (mut self Coordinator) restart() ! {
+pub fn (mut self Coordinator) restart(args StartArgs) ! {
 	switch(self.name)
 	self.stop()!
-	self.start()!
+	self.start(args)!
 }
 
 pub fn (mut self Coordinator) running() !bool {

--- a/lib/installers/horus/herorunner/herorunner_actions.v
+++ b/lib/installers/horus/herorunner/herorunner_actions.v
@@ -9,8 +9,16 @@ import incubaid.herolib.installers.lang.rust
 import incubaid.herolib.develop.gittools
 import os
 
-fn (self &Herorunner) startupcmd() ![]startupmanager.ZProcessNewArgs {
+@[params]
+pub struct StartArgs {
+pub mut:
+	reset bool
+}
+
+fn (self &Herorunner) startupcmd(args StartArgs) ![]startupmanager.ZProcessNewArgs {
 	mut res := []startupmanager.ZProcessNewArgs{}
+
+	reset := args.reset
 
 	// Ensure redis_addr has the redis:// prefix
 	redis_url := if self.redis_addr.starts_with('redis://') {
@@ -20,9 +28,10 @@ fn (self &Herorunner) startupcmd() ![]startupmanager.ZProcessNewArgs {
 	}
 
 	res << startupmanager.ZProcessNewArgs{
-		name: 'herorunner'
-		cmd:  '${self.binary_path} --redis-url ${redis_url} 12001'
-		env:  {
+		name:  'herorunner'
+		cmd:   '${self.binary_path} --redis-url ${redis_url} 12001'
+		reset: reset
+		env:   {
 			'HOME':           os.home_dir()
 			'RUST_LOG':       self.log_level
 			'RUST_LOG_STYLE': 'never'

--- a/lib/installers/horus/herorunner/herorunner_factory_.v
+++ b/lib/installers/horus/herorunner/herorunner_factory_.v
@@ -164,7 +164,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'start' {
 				console.print_debug('install action herorunner.${other_action.name}')
-				herorunner_obj.start()!
+				herorunner_obj.start(reset: reset)!
 			}
 			if other_action.name == 'stop' {
 				console.print_debug('install action herorunner.${other_action.name}')
@@ -172,7 +172,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'restart' {
 				console.print_debug('install action herorunner.${other_action.name}')
-				herorunner_obj.restart()!
+				herorunner_obj.restart(reset: reset)!
 			}
 			if other_action.name == 'start_pre' {
 				console.print_debug('install action herorunner.${other_action.name}')
@@ -231,7 +231,7 @@ pub fn (mut self Herorunner) reload() ! {
 	self = obj_init(self)!
 }
 
-pub fn (mut self Herorunner) start() ! {
+pub fn (mut self Herorunner) start(args StartArgs) ! {
 	switch(self.name)
 	if self.running()! {
 		return
@@ -245,7 +245,7 @@ pub fn (mut self Herorunner) start() ! {
 
 	self.start_pre()!
 
-	for zprocess in self.startupcmd()! {
+	for zprocess in self.startupcmd(args)! {
 		mut sm := startupmanager_get(zprocess.startuptype)!
 
 		console.print_debug('installer: herorunner starting with ${zprocess.startuptype}...')
@@ -269,7 +269,7 @@ pub fn (mut self Herorunner) start() ! {
 pub fn (mut self Herorunner) install_start(args InstallArgs) ! {
 	switch(self.name)
 	self.install(args)!
-	self.start()!
+	self.start(reset: false)!
 }
 
 pub fn (mut self Herorunner) stop() ! {
@@ -282,10 +282,10 @@ pub fn (mut self Herorunner) stop() ! {
 	self.stop_post()!
 }
 
-pub fn (mut self Herorunner) restart() ! {
+pub fn (mut self Herorunner) restart(args StartArgs) ! {
 	switch(self.name)
 	self.stop()!
-	self.start()!
+	self.start(args)!
 }
 
 pub fn (mut self Herorunner) running() !bool {

--- a/lib/installers/horus/osirisrunner/osirisrunner_actions.v
+++ b/lib/installers/horus/osirisrunner/osirisrunner_actions.v
@@ -9,8 +9,16 @@ import incubaid.herolib.installers.lang.rust
 import incubaid.herolib.develop.gittools
 import os
 
-fn (self &Osirisrunner) startupcmd() ![]startupmanager.ZProcessNewArgs {
+@[params]
+pub struct StartArgs {
+pub mut:
+	reset bool
+}
+
+fn (self &Osirisrunner) startupcmd(args StartArgs) ![]startupmanager.ZProcessNewArgs {
 	mut res := []startupmanager.ZProcessNewArgs{}
+
+	reset := args.reset
 
 	// Ensure redis_addr has the redis:// prefix
 	redis_url := if self.redis_addr.starts_with('redis://') {
@@ -20,9 +28,10 @@ fn (self &Osirisrunner) startupcmd() ![]startupmanager.ZProcessNewArgs {
 	}
 
 	res << startupmanager.ZProcessNewArgs{
-		name: 'runner_osiris'
-		cmd:  '${self.binary_path} --redis-url ${redis_url} 12002'
-		env:  {
+		name:  'runner_osiris'
+		cmd:   '${self.binary_path} --redis-url ${redis_url} 12002'
+		reset: reset
+		env:   {
 			'HOME':           os.home_dir()
 			'RUST_LOG':       self.log_level
 			'RUST_LOG_STYLE': 'never'

--- a/lib/installers/horus/osirisrunner/osirisrunner_factory_.v
+++ b/lib/installers/horus/osirisrunner/osirisrunner_factory_.v
@@ -166,7 +166,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'start' {
 				console.print_debug('install action osirisrunner.${other_action.name}')
-				osirisrunner_obj.start()!
+				osirisrunner_obj.start(reset: reset)!
 			}
 			if other_action.name == 'stop' {
 				console.print_debug('install action osirisrunner.${other_action.name}')
@@ -174,7 +174,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'restart' {
 				console.print_debug('install action osirisrunner.${other_action.name}')
-				osirisrunner_obj.restart()!
+				osirisrunner_obj.restart(reset: reset)!
 			}
 			if other_action.name == 'start_pre' {
 				console.print_debug('install action osirisrunner.${other_action.name}')
@@ -233,7 +233,7 @@ pub fn (mut self Osirisrunner) reload() ! {
 	self = obj_init(self)!
 }
 
-pub fn (mut self Osirisrunner) start() ! {
+pub fn (mut self Osirisrunner) start(args StartArgs) ! {
 	switch(self.name)
 	if self.running()! {
 		return
@@ -247,7 +247,7 @@ pub fn (mut self Osirisrunner) start() ! {
 
 	self.start_pre()!
 
-	for zprocess in self.startupcmd()! {
+	for zprocess in self.startupcmd(args)! {
 		mut sm := startupmanager_get(zprocess.startuptype)!
 
 		console.print_debug('installer: osirisrunner starting with ${zprocess.startuptype}...')
@@ -271,7 +271,7 @@ pub fn (mut self Osirisrunner) start() ! {
 pub fn (mut self Osirisrunner) install_start(args InstallArgs) ! {
 	switch(self.name)
 	self.install(args)!
-	self.start()!
+	self.start(reset: false)!
 }
 
 pub fn (mut self Osirisrunner) stop() ! {
@@ -284,10 +284,10 @@ pub fn (mut self Osirisrunner) stop() ! {
 	self.stop_post()!
 }
 
-pub fn (mut self Osirisrunner) restart() ! {
+pub fn (mut self Osirisrunner) restart(args StartArgs) ! {
 	switch(self.name)
 	self.stop()!
-	self.start()!
+	self.start(args)!
 }
 
 pub fn (mut self Osirisrunner) running() !bool {

--- a/lib/installers/horus/salrunner/salrunner_actions.v
+++ b/lib/installers/horus/salrunner/salrunner_actions.v
@@ -9,8 +9,16 @@ import incubaid.herolib.installers.lang.rust
 import incubaid.herolib.develop.gittools
 import os
 
-fn (self &Salrunner) startupcmd() ![]startupmanager.ZProcessNewArgs {
+@[params]
+pub struct StartArgs {
+pub mut:
+	reset bool
+}
+
+fn (self &Salrunner) startupcmd(args StartArgs) ![]startupmanager.ZProcessNewArgs {
 	mut res := []startupmanager.ZProcessNewArgs{}
+
+	reset := args.reset
 
 	// Ensure redis_addr has the redis:// prefix
 	redis_url := if self.redis_addr.starts_with('redis://') {
@@ -20,9 +28,10 @@ fn (self &Salrunner) startupcmd() ![]startupmanager.ZProcessNewArgs {
 	}
 
 	res << startupmanager.ZProcessNewArgs{
-		name: 'runner_sal'
-		cmd:  '${self.binary_path} --redis-url ${redis_url} 12003'
-		env:  {
+		name:  'runner_sal'
+		cmd:   '${self.binary_path} --redis-url ${redis_url} 12003'
+		reset: reset
+		env:   {
 			'HOME':           os.home_dir()
 			'RUST_LOG':       self.log_level
 			'RUST_LOG_STYLE': 'never'

--- a/lib/installers/horus/salrunner/salrunner_factory_.v
+++ b/lib/installers/horus/salrunner/salrunner_factory_.v
@@ -166,7 +166,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'start' {
 				console.print_debug('install action salrunner.${other_action.name}')
-				salrunner_obj.start()!
+				salrunner_obj.start(reset: reset)!
 			}
 			if other_action.name == 'stop' {
 				console.print_debug('install action salrunner.${other_action.name}')
@@ -174,7 +174,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'restart' {
 				console.print_debug('install action salrunner.${other_action.name}')
-				salrunner_obj.restart()!
+				salrunner_obj.restart(reset: reset)!
 			}
 			if other_action.name == 'start_pre' {
 				console.print_debug('install action salrunner.${other_action.name}')
@@ -233,7 +233,7 @@ pub fn (mut self Salrunner) reload() ! {
 	self = obj_init(self)!
 }
 
-pub fn (mut self Salrunner) start() ! {
+pub fn (mut self Salrunner) start(args StartArgs) ! {
 	switch(self.name)
 	if self.running()! {
 		return
@@ -247,7 +247,7 @@ pub fn (mut self Salrunner) start() ! {
 
 	self.start_pre()!
 
-	for zprocess in self.startupcmd()! {
+	for zprocess in self.startupcmd(args)! {
 		mut sm := startupmanager_get(zprocess.startuptype)!
 
 		console.print_debug('installer: salrunner starting with ${zprocess.startuptype}...')
@@ -271,7 +271,7 @@ pub fn (mut self Salrunner) start() ! {
 pub fn (mut self Salrunner) install_start(args InstallArgs) ! {
 	switch(self.name)
 	self.install(args)!
-	self.start()!
+	self.start(reset: false)!
 }
 
 pub fn (mut self Salrunner) stop() ! {
@@ -284,10 +284,10 @@ pub fn (mut self Salrunner) stop() ! {
 	self.stop_post()!
 }
 
-pub fn (mut self Salrunner) restart() ! {
+pub fn (mut self Salrunner) restart(args StartArgs) ! {
 	switch(self.name)
 	self.stop()!
-	self.start()!
+	self.start(args)!
 }
 
 pub fn (mut self Salrunner) running() !bool {

--- a/lib/installers/horus/supervisor/supervisor_actions.v
+++ b/lib/installers/horus/supervisor/supervisor_actions.v
@@ -10,8 +10,16 @@ import incubaid.herolib.installers.lang.rust
 import incubaid.herolib.develop.gittools
 import os
 
-fn (self &Supervisor) startupcmd() ![]startupmanager.ZProcessNewArgs {
+@[params]
+pub struct StartArgs {
+pub mut:
+	reset bool
+}
+
+fn (self &Supervisor) startupcmd(args StartArgs) ![]startupmanager.ZProcessNewArgs {
 	mut res := []startupmanager.ZProcessNewArgs{}
+
+	reset := args.reset
 
 	// Ensure redis_addr has the redis:// prefix
 	redis_url := if self.redis_addr.starts_with('redis://') {
@@ -21,9 +29,10 @@ fn (self &Supervisor) startupcmd() ![]startupmanager.ZProcessNewArgs {
 	}
 
 	res << startupmanager.ZProcessNewArgs{
-		name: 'supervisor'
-		cmd:  '${self.binary_path} --redis-url ${redis_url} --port ${self.http_port} --admin-secret mysecret'
-		env:  {
+		name:  'supervisor'
+		cmd:   '${self.binary_path} --redis-url ${redis_url} --port ${self.http_port} --admin-secret mysecret'
+		reset: reset
+		env:   {
 			'HOME':           os.home_dir()
 			'RUST_LOG':       self.log_level
 			'RUST_LOG_STYLE': 'never'

--- a/lib/installers/horus/supervisor/supervisor_factory_.v
+++ b/lib/installers/horus/supervisor/supervisor_factory_.v
@@ -178,11 +178,12 @@ pub fn play(mut plbook PlayBook) ! {
 			'stop_post'] {
 			mut p := other_action.params
 			name := p.get('name')!
+			reset := p.get_default_false('reset')
 			mut supervisor_obj := get(name: name, create: true)!
 			console.print_debug('action object:\n${supervisor_obj}')
 			if other_action.name == 'start' {
 				console.print_debug('install action supervisor.${other_action.name}')
-				supervisor_obj.start()!
+				supervisor_obj.start(reset: reset)!
 			}
 			if other_action.name == 'stop' {
 				console.print_debug('install action supervisor.${other_action.name}')
@@ -190,7 +191,7 @@ pub fn play(mut plbook PlayBook) ! {
 			}
 			if other_action.name == 'restart' {
 				console.print_debug('install action supervisor.${other_action.name}')
-				supervisor_obj.restart()!
+				supervisor_obj.restart(reset: reset)!
 			}
 			if other_action.name == 'start_pre' {
 				console.print_debug('install action supervisor.${other_action.name}')
@@ -249,7 +250,7 @@ pub fn (mut self Supervisor) reload() ! {
 	self = obj_init(self)!
 }
 
-pub fn (mut self Supervisor) start() ! {
+pub fn (mut self Supervisor) start(args StartArgs) ! {
 	switch(self.name)
 	if self.running()! {
 		return
@@ -265,7 +266,7 @@ pub fn (mut self Supervisor) start() ! {
 
 	self.start_pre()!
 
-	for zprocess in self.startupcmd()! {
+	for zprocess in self.startupcmd(args)! {
 		mut sm := startupmanager_get(zprocess.startuptype)!
 
 		console.print_debug('installer: supervisor starting with ${zprocess.startuptype}...')
@@ -289,7 +290,7 @@ pub fn (mut self Supervisor) start() ! {
 pub fn (mut self Supervisor) install_start(args InstallArgs) ! {
 	switch(self.name)
 	self.install(args)!
-	self.start()!
+	self.start(reset: false)!
 }
 
 pub fn (mut self Supervisor) stop() ! {
@@ -302,10 +303,10 @@ pub fn (mut self Supervisor) stop() ! {
 	self.stop_post()!
 }
 
-pub fn (mut self Supervisor) restart() ! {
+pub fn (mut self Supervisor) restart(args StartArgs) ! {
 	switch(self.name)
 	self.stop()!
-	self.start()!
+	self.start(args)!
 }
 
 pub fn (mut self Supervisor) running() !bool {

--- a/lib/osal/startupmanager/model.v
+++ b/lib/osal/startupmanager/model.v
@@ -22,6 +22,7 @@ pub mut:
 	oneshot     bool
 	start       bool = true
 	restart     bool = true // whether the process should be restarted on failure
+	reset       bool   // if true, will delete and recreate existing service; if false, will skip if config matches or error if config differs
 	description string // not used in zinit
 	startuptype StartupManagerType
 }

--- a/lib/osal/startupmanager/startupmanager.v
+++ b/lib/osal/startupmanager/startupmanager.v
@@ -105,20 +105,54 @@ pub fn (mut sm StartupManager) new(args ZProcessNewArgs) ! {
 			// Check if service already exists
 			existing_service := zinit_client.service_get(args.name) or { zinit.ServiceConfig{} }
 
-			// If service exists, stop monitoring, stop, and delete it first
+			// Smart service creation logic based on reset flag
 			if existing_service.exec.len > 0 {
-				console.print_debug('startupmanager: service ${args.name} already exists, cleaning up...')
-				// Stop the service first
-				zinit_client.service_stop(args.name) or {
-					console.print_debug('startupmanager: failed to stop service ${args.name}: ${err}')
-				}
-				// Forget (stop monitoring) the service
-				zinit_client.service_forget(args.name) or {
-					console.print_debug('startupmanager: failed to forget service ${args.name}: ${err}')
-				}
-				// Delete the service configuration
-				zinit_client.service_delete(args.name) or {
-					console.print_debug('startupmanager: failed to delete service ${args.name}: ${err}')
+				// Service exists - check if configuration matches
+				configs_match := existing_service.exec == service_config.exec
+					&& existing_service.test == service_config.test
+					&& existing_service.oneshot == service_config.oneshot
+					&& existing_service.dir == service_config.dir
+					&& existing_service.log == service_config.log
+					&& existing_service.after.len == service_config.after.len
+					&& existing_service.env.len == service_config.env.len
+
+				if configs_match {
+					// Configuration is the same - idempotent, just skip creation
+					console.print_debug('startupmanager: service ${args.name} already exists with same configuration, skipping creation.')
+					// If start is requested and service is not running, start it
+					if args.start {
+						status := zinit_client.service_status(args.name) or {
+							console.print_debug('startupmanager: failed to get status of ${args.name}: ${err}')
+							zinit.ServiceStatus{}
+						}
+						if status.state != 'Running' {
+							console.print_debug('startupmanager: service ${args.name} is not running, starting it...')
+							zinit_client.service_monitor(args.name) or {
+								console.print_debug('startupmanager: failed to monitor service ${args.name}: ${err}')
+							}
+						}
+					}
+					return
+				} else {
+					// Configuration is different
+					if !args.reset {
+						// reset is false - return error to protect user customizations
+						return error('service ${args.name} already exists with different configuration. Use reset:true to overwrite it.')
+					}
+					// reset is true - delete and recreate
+					console.print_debug('startupmanager: service ${args.name} exists with different configuration, recreating (reset:true)...')
+					// Stop the service first
+					zinit_client.service_stop(args.name) or {
+						console.print_debug('startupmanager: failed to stop service ${args.name}: ${err}')
+					}
+					// Forget (stop monitoring) the service
+					zinit_client.service_forget(args.name) or {
+						console.print_debug('startupmanager: failed to forget service ${args.name}: ${err}')
+					}
+					// Delete the service configuration
+					zinit_client.service_delete(args.name) or {
+						console.print_debug('startupmanager: failed to delete service ${args.name}: ${err}')
+					}
 				}
 			}
 

--- a/lib/schemas/jsonrpc/transport_unixsocket.v
+++ b/lib/schemas/jsonrpc/transport_unixsocket.v
@@ -76,17 +76,13 @@ pub fn (mut t UnixSocketTransport) send(request string, params SendParams) !stri
 		// Append the newly read data to the total response
 		res_total << res[..n]
 
-		// here we need to check we are at end
-		if res.bytestr().contains('\n') {
+		// Check if we have received a complete response (ends with newline)
+		if res_total.bytestr().contains('\n') {
 			break
 		}
 	}
 	unix.shutdown(socket.sock.handle)
 	socket.close() or {}
-
-	// println(res_total.bytestr().trim_space())
-
-	// println(19)
 
 	// Convert response to string and trim whitespace
 	mut response := res_total.bytestr().trim_space()


### PR DESCRIPTION
### Changes 

- Update default coordinator name to 'coordinator'
- Improve status reporting by using dedicated variables
- Adjust `zinit.get` call to use `create: true`
- Set `zinit_default` based on `args.name` when 'default' is provided
- Update `coordinatorServer.name` default to 'coordinator'
- Make 'coordinator' the default for `ArgsGet.name`
- Use `coordinator_default` for `ArgsGet.name` if set
- Adjust `CoordinatorServer.binary_path` default
- Update `zinit.get` to use `create: true`
- Log socket closure for debugging
- Remove unused import `incubaid.herolib.core.texttools`

### Related Issues

- https://github.com/Incubaid/herolib/issues/203