### PR TITLE
refactor: Improve const and param parsing logic

### DIFF
--- a/lib/core/code/model_const.v
+++ b/lib/core/code/model_const.v
@@ -11,8 +11,13 @@ pub fn parse_const(code_ string) !Const {
 	if !code.contains('=') {
 		return error('code <${code_}> is not of const')
 	}
+	mut name := code.split('=')[0].trim_space()
+	// Strip 'const ' prefix if present
+	if name.starts_with('const ') {
+		name = name.trim_string_left('const ').trim_space()
+	}
 	return Const{
-		name:  code.split('=')[0].trim_space()
+		name:  name
 		value: code.split('=')[1].trim_space()
 	}
 }

--- a/lib/core/code/model_param.v
+++ b/lib/core/code/model_param.v
@@ -44,6 +44,11 @@ pub fn (p Param) typescript() string {
 pub fn parse_param(code_ string) !Param {
 	mut code := code_.trim_space()
 
+	// Handle empty string (void return type)
+	if code == '' {
+		return Param{}
+	}
+
 	if code == '!' {
 		return Param{
 			is_result: true
@@ -59,6 +64,13 @@ pub fn parse_param(code_ string) !Param {
 		code = code.trim_string_left('mut ').trim_space()
 	}
 	split := code.split(' ').filter(it != '')
+
+	// Handle empty split (void return type after mut check)
+	if split.len == 0 {
+		return Param{
+			mutable: is_mut
+		}
+	}
 
 	if split.len == 1 {
 		// means anonymous param

--- a/lib/core/codeparser/advanced_test.v
+++ b/lib/core/codeparser/advanced_test.v
@@ -15,14 +15,14 @@ fn test_comprehensive_code_parsing() {
 	console.print_lf(1)
 
 	// Run all tests
-	test_module_parsing()
-	test_struct_parsing()
-	test_function_parsing()
-	test_imports_and_modules()
-	test_type_system()
-	test_visibility_modifiers()
-	test_method_parsing()
-	test_constants_parsing()
+	check_module_parsing()!
+	check_struct_parsing()
+	check_function_parsing()!
+	check_imports_and_modules()
+	check_type_system()
+	check_visibility_modifiers()
+	check_method_parsing()!
+	check_constants_parsing()
 
 	console.print_green('✓ All comprehensive tests passed!')
 	console.print_lf(1)
@@ -74,7 +74,7 @@ fn copy_directory(src string, dst string) ! {
 	}
 }
 
-fn test_module_parsing() {
+fn check_module_parsing() ! {
 	console.print_header('Test 1: Module and File Parsing')
 
 	mut myparser := new(path: '/tmp/codeparsertest', recursive: true)!
@@ -98,7 +98,7 @@ fn test_module_parsing() {
 	console.print_lf(1)
 }
 
-fn test_struct_parsing() {
+fn check_struct_parsing() {
 	console.print_header('Test 2: Struct Parsing')
 
 	models_file := os.join_path('/tmp/codeparsertest', 'models.v')
@@ -145,7 +145,7 @@ fn test_struct_parsing() {
 	console.print_lf(1)
 }
 
-fn test_function_parsing() {
+fn check_function_parsing() ! {
 	console.print_header('Test 3: Function Parsing')
 
 	mut myparser := new(path: '/tmp/codeparsertest', recursive: true)!
@@ -191,7 +191,7 @@ fn test_function_parsing() {
 	console.print_lf(1)
 }
 
-fn test_imports_and_modules() {
+fn check_imports_and_modules() {
 	console.print_header('Test 4: Imports and Module Names')
 
 	models_file := os.join_path('/tmp/codeparsertest', 'models.v')
@@ -222,7 +222,7 @@ fn test_imports_and_modules() {
 	console.print_lf(1)
 }
 
-fn test_type_system() {
+fn check_type_system() {
 	console.print_header('Test 5: Type System')
 
 	models_file := os.join_path('/tmp/codeparsertest', 'models.v')
@@ -257,7 +257,7 @@ fn test_type_system() {
 	console.print_lf(1)
 }
 
-fn test_visibility_modifiers() {
+fn check_visibility_modifiers() {
 	console.print_header('Test 6: Visibility Modifiers')
 
 	models_file := os.join_path('/tmp/codeparsertest', 'models.v')
@@ -293,7 +293,7 @@ fn test_visibility_modifiers() {
 	console.print_lf(1)
 }
 
-fn test_method_parsing() {
+fn check_method_parsing() ! {
 	console.print_header('Test 7: Method Parsing')
 
 	mut myparser := new(path: '/tmp/codeparsertest', recursive: true)!
@@ -327,7 +327,7 @@ fn test_method_parsing() {
 	console.print_lf(1)
 }
 
-fn test_constants_parsing() {
+fn check_constants_parsing() {
 	console.print_header('Test 8: Constants Parsing')
 
 	models_file := os.join_path('/tmp/codeparsertest', 'models.v')


### PR DESCRIPTION
### Changes

- Strip 'const ' prefix from const name
- Handle empty string for void param return type
- Handle empty split for void param return type
- Rename test functions to check functions
- Add `!` to functions that can return errors

### Related Issues

- https://github.com/Incubaid/herolib/issues/207