### PR TITLE
fix: use GitHub 'latest' release URL in install_hero.sh

### DIFF
--- a/docker/herolib/Dockerfile
+++ b/docker/herolib/Dockerfile
@@ -40,4 +40,3 @@ RUN /tmp/install_herolib.vsh && \
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/bin/bash"]
-

--- a/scripts/install_hero.sh
+++ b/scripts/install_hero.sh
@@ -4,28 +4,18 @@ set -e
 
 os_name="$(uname -s)"
 arch_name="$(uname -m)"
-version='1.0.38'
 
-# Detect Linux distribution type
-linux_type=""
-if [[ "$os_name" == "Linux" ]]; then
-    if [ -f /etc/os-release ]; then
-        linux_type="$(. /etc/os-release && echo "$ID")"
-    fi
-fi
+# Base URL for GitHub releases (uses 'latest' to always get the most recent version)
+base_url="https://github.com/incubaid/herolib/releases/latest/download"
 
-# Base URL for GitHub releases
-base_url="https://github.com/incubaid/herolib/releases/download/v${version}"
-
-# Select the URL based on the platform. For Linux we have a single static binary
+# Select the URL based on the platform
+# Always use musl for Linux (static binary, works everywhere)
 if [[ "$os_name" == "Linux" && "$arch_name" == "x86_64" ]]; then
     url="$base_url/hero-x86_64-linux-musl"
 elif [[ "$os_name" == "Linux" && "$arch_name" == "aarch64" ]]; then
     url="$base_url/hero-aarch64-linux-musl"
 elif [[ "$os_name" == "Darwin" && "$arch_name" == "arm64" ]]; then
     url="$base_url/hero-aarch64-apple-darwin"
-# elif [[ "$os_name" == "Darwin" && "$arch_name" == "x86_64" ]]; then
-#     url="$base_url/hero-x86_64-apple-darwin"
 else
     echo "Unsupported platform: $os_name $arch_name"
     exit 1
@@ -45,7 +35,7 @@ if [ ! -z "$existing_hero" ]; then
     fi
 fi
 
-if [[ "${OSNAME}" == "darwin"* ]]; then
+if [[ "$os_name" == "Darwin" ]]; then
     # Check if /usr/local/bin/hero exists and remove it
     if [ -f /usr/local/bin/hero ]; then
         rm /usr/local/bin/hero || { echo "Error: Failed to remove existing hero binary"; exit 1; }
@@ -85,30 +75,33 @@ fi
 
 if [ -z "$url" ]; then
     echo "Could not find url to download."
-    echo $urls
     exit 1
 fi
-zprofile="${HOME}/.zprofile"
-hero_bin_path="${HOME}/hero/bin"
-temp_file="$(mktemp)"
 
-# Check if ~/.zprofile exists
-if [ -f "$zprofile" ]; then
-    # Read each line and exclude any that modify the PATH with ~/hero/bin
-    while IFS= read -r line; do
-        if [[ ! "$line" =~ $hero_bin_path ]]; then
-            echo "$line" >> "$temp_file"
-        fi
-    done < "$zprofile"
-else
-    touch "$zprofile"
+hero_bin_path="${HOME}/hero/bin"
+
+# Only modify .zprofile on macOS (where we install to ~/hero/bin)
+if [[ "$os_name" == "Darwin" ]]; then
+    zprofile="${HOME}/.zprofile"
+    temp_file="$(mktemp)"
+    trap 'rm -f "$temp_file"' EXIT
+
+    # Check if ~/.zprofile exists
+    if [ -f "$zprofile" ]; then
+        # Read each line and exclude any that modify the PATH with ~/hero/bin
+        while IFS= read -r line; do
+            if [[ ! "$line" =~ $hero_bin_path ]]; then
+                echo "$line" >> "$temp_file"
+            fi
+        done < "$zprofile"
+    else
+        touch "$zprofile"
+    fi
+    # Add ~/hero/bin to the PATH statement
+    echo "export PATH=\$PATH:$hero_bin_path" >> "$temp_file"
+    # Replace the original .zprofile with the modified version
+    mv "$temp_file" "$zprofile"
 fi
-# Add ~/hero/bin to the PATH statement
-echo "export PATH=\$PATH:$hero_bin_path" >> "$temp_file"
-# Replace the original .zprofile with the modified version
-mv "$temp_file" "$zprofile"
-# Ensure the temporary file is removed (in case of script interruption before mv)
-trap 'rm -f "$temp_file"' EXIT
 
 # Output the selected URL
 echo "Download URL for your platform: $url"
@@ -119,21 +112,21 @@ curl -o /tmp/downloaded_file -L "$url"
 set -e
 
 # Check if file size is greater than 2 MB
-file_size=$(du -m  /tmp/downloaded_file | cut -f1)
+file_size=$(du -m /tmp/downloaded_file | cut -f1)
 if [ "$file_size" -ge 2 ]; then
-    # Create the target directory if it doesn't exist
-    mkdir -p ~/hero/bin
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # Move and rename the file
-        mv  /tmp/downloaded_file ~/hero/bin/hero
+    if [[ "$os_name" == "Darwin" ]]; then
+        # macOS: install to ~/hero/bin
+        mkdir -p ~/hero/bin
+        mv /tmp/downloaded_file ~/hero/bin/hero
         chmod +x ~/hero/bin/hero
+        export PATH=$PATH:$hero_bin_path
     else
-        mv  /tmp/downloaded_file /usr/local/bin/hero
+        # Linux: install to /usr/local/bin
+        mv /tmp/downloaded_file /usr/local/bin/hero
         chmod +x /usr/local/bin/hero
     fi
 
     echo "Hero installed properly"
-    export PATH=$PATH:$hero_bin_path
     hero -version
 else
     echo "Downloaded file is less than 2 MB. Process aborted."


### PR DESCRIPTION
## Summary
- Remove hardcoded version, use `releases/latest/download` instead
- Always use musl builds for Linux (static binary works everywhere)
- Fix variable name bugs (`OSNAME` -> `os_name`, `OSTYPE` -> `os_name`)
- Only modify `.zprofile` on macOS (not Linux)
- Remove dead code

## Test plan
- [ ] Test on Linux x86_64
- [ ] Test on Linux aarch64
- [ ] Test on macOS arm64