### PR TITLE
Support loading all SSH keys on Hetzner server 

### DIFF
--- a/examples/virt/hetzner/hetzner_env.sh
+++ b/examples/virt/hetzner/hetzner_env.sh
@@ -1,3 +1,0 @@
-export HETZNER_USER="#ws+JdQtGCdL"
-export HETZNER_PASSWORD="Kds007kds!"
-export HETZNER_SSHKEY_NAME="mahmoud"

--- a/examples/virt/hetzner/hetzner_example.hero
+++ b/examples/virt/hetzner/hetzner_example.hero
@@ -1,34 +1,35 @@
 #!/usr/bin/env hero
 
-// # Configure HetznerManager, replace with your own credentials, server id's and ssh key name and all other parameters
 
-!!hetznermanager.configure
-	user:"user_name"
-	whitelist:"server_id"
-	password:"password"
-	sshkey:"ssh_key_name"
+// !!hetznermanager.configure
+// 	name:"main"
+// 	user:"krist"
+// 	whitelist:"2111181, 2392178, 2545053, 2542166, 2550508, 2550378,2550253"
+// 	password:"wontsethere"
+// 	sshkey:"kristof"
 
-!!hetznermanager.server_rescue
-    server_name: 'server_name'  // The name of the server to manage (or use `id`)
-    wait: true                     // Wait for the operation to complete
-    hero_install: true             // Automatically install Herolib in the rescue system
+
+// !!hetznermanager.server_rescue
+//     server_name: 'kristof21'  // The name of the server to manage (or use `id`)
+//     wait: true                     // Wait for the operation to complete
+//     hero_install: true             // Automatically install Herolib in the rescue system
 
 
 // # Reset a server
-!!hetznermanager.server_reset
-    instance: 'main'
-    server_name: 'server_name'
-    wait: true
+// !!hetznermanager.server_reset
+//     instance: 'main'
+//     server_name: 'your-server-name'
+//     wait: true
 
 // # Add a new SSH key to your Hetzner account
-!!hetznermanager.key_create
-    instance: 'main'
-    key_name: 'ssh_key_name'
-    data: 'ssh-rsa AAAA...'
+// !!hetznermanager.key_create
+//     instance: 'main'
+//     key_name: 'my-laptop-key'
+//     data: 'ssh-rsa AAAA...'
 
 
 // Install Ubuntu 24.04 on a server
 !!hetznermanager.ubuntu_install
-    server_name: 'server_name'
+    server_name: 'kristof2'
     wait: true
     hero_install: true            // Install Herolib on the new OS

--- a/examples/virt/hetzner/hetzner_kristof1.vsh
+++ b/examples/virt/hetzner/hetzner_kristof1.vsh
@@ -24,7 +24,7 @@ hs := '
 	user:"${user}"
 	whitelist:"2521602,2555487,2573047"
 	password:"${passwd}"
-	sshkey:"kristof"
+	sshkey:"*"
 '
 
 println(hs)
@@ -55,7 +55,7 @@ println(serverinfo)
 
 // console.print_header('SSH login')
 
-cl.ubuntu_install(name: name, wait: true, hero_install: true)!
+cl.ubuntu_install(name: name, wait: true, hero_install: true, reinstall: true)!
 // cl.ubuntu_install(name: 'kristof20', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550378, name: 'kristof21', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550508, name: 'kristof22', wait: true, hero_install: true)!

--- a/examples/virt/hetzner/hetzner_kristof1.vsh
+++ b/examples/virt/hetzner/hetzner_kristof1.vsh
@@ -8,33 +8,23 @@ import time
 import os
 import incubaid.herolib.core.playcmds
 
-// Server-specific configuration
-const server_name = 'kristof1'
-const server_whitelist = '2521602'
+name := 'kristof1'
 
-// Load credentials from environment variables
-// Source hetzner_env.sh before running: source examples/virt/hetzner/hetzner_env.sh
-hetzner_user := os.environ()['HETZNER_USER'] or {
+user := os.environ()['HETZNER_USER'] or {
 	println('HETZNER_USER not set')
 	exit(1)
 }
-
-hetzner_passwd := os.environ()['HETZNER_PASSWORD'] or {
+passwd := os.environ()['HETZNER_PASSWORD'] or {
 	println('HETZNER_PASSWORD not set')
-	exit(1)
-}
-
-hetzner_sshkey_name := os.environ()['HETZNER_SSHKEY_NAME'] or {
-	println('HETZNER_SSHKEY_NAME not set')
 	exit(1)
 }
 
 hs := '
 !!hetznermanager.configure
-	user:"${hetzner_user}"
-	whitelist:"${server_whitelist}"
-	password:"${hetzner_passwd}"
-	sshkey:"${hetzner_sshkey_name}"
+	user:"${user}"
+	whitelist:"2521602,2555487,2573047"
+	password:"${passwd}"
+	sshkey:"kristof"
 '
 
 println(hs)
@@ -52,7 +42,7 @@ mut cl := hetznermanager.get()!
 
 println(cl.servers_list()!)
 
-mut serverinfo := cl.server_info_get(name: server_name)!
+mut serverinfo := cl.server_info_get(name: name)!
 
 println(serverinfo)
 
@@ -65,7 +55,7 @@ println(serverinfo)
 
 // console.print_header('SSH login')
 
-cl.ubuntu_install(name: server_name, wait: true, hero_install: true)!
+cl.ubuntu_install(name: name, wait: true, hero_install: true)!
 // cl.ubuntu_install(name: 'kristof20', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550378, name: 'kristof21', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550508, name: 'kristof22', wait: true, hero_install: true)!

--- a/examples/virt/hetzner/hetzner_kristof2.vsh
+++ b/examples/virt/hetzner/hetzner_kristof2.vsh
@@ -8,47 +8,62 @@ import time
 import os
 import incubaid.herolib.core.playcmds
 
-// Server-specific configuration
-const server_name = 'kristof2'
-const server_whitelist = '2555487'
+name := 'kristof2'
 
-// Load credentials from environment variables
-// Source hetzner_env.sh before running: source examples/virt/hetzner/hetzner_env.sh
-hetzner_user := os.environ()['HETZNER_USER'] or {
+user := os.environ()['HETZNER_USER'] or {
 	println('HETZNER_USER not set')
 	exit(1)
 }
-
-hetzner_passwd := os.environ()['HETZNER_PASSWORD'] or {
+passwd := os.environ()['HETZNER_PASSWORD'] or {
 	println('HETZNER_PASSWORD not set')
 	exit(1)
 }
 
-hetzner_sshkey_name := os.environ()['HETZNER_SSHKEY_NAME'] or {
-	println('HETZNER_SSHKEY_NAME not set')
-	exit(1)
-}
-
-hero_script := '
+hs := '
 !!hetznermanager.configure
-	user:"${hetzner_user}"
-	whitelist:"${server_whitelist}"
-	password:"${hetzner_passwd}"
-	sshkey:"${hetzner_sshkey_name}"
+	user:"${user}"
+	whitelist:"2521602,2555487"
+	password:"${passwd}"
+	sshkey:"kristof"
 '
 
-playcmds.run(heroscript: hero_script)!
-mut hetznermanager_ := hetznermanager.get()!
+println(hs)
 
-mut serverinfo := hetznermanager_.server_info_get(name: server_name)!
+playcmds.run(heroscript: hs)!
 
-println('${server_name} ${serverinfo.server_ip}')
+console.print_header('Hetzner Test.')
 
-hetznermanager_.server_rescue(name: server_name, wait: true, hero_install: true)!
-mut keys := hetznermanager_.keys_get()!
+mut cl := hetznermanager.get()!
+// println(cl)
 
+// for i in 0 .. 5 {
+// 	println('test cache, first time slow then fast')
+// }
+
+println(cl.servers_list()!)
+
+mut serverinfo := cl.server_info_get(name: name)!
+
+println(serverinfo)
+
+// cl.server_reset(name: 'kristof2', wait: true)!
+
+cl.server_rescue(name: name, wait: true, hero_install: true)!
+
+mut ks := cl.keys_get()!
+println(ks)
+
+console.print_header('SSH login')
 mut b := builder.new()!
 mut n := b.node_new(ipaddr: serverinfo.server_ip)!
 
-hetznermanager_.ubuntu_install(name: server_name, wait: true, hero_install: true)!
+// this will put hero in debug mode on the system
+// n.hero_install(compile: true)!
+
 n.shell('')!
+
+cl.ubuntu_install(name: name, wait: true, hero_install: true)!
+// cl.ubuntu_install(name: 'kristof20', wait: true, hero_install: true)!
+// cl.ubuntu_install(id:2550378, name: 'kristof21', wait: true, hero_install: true)!
+// cl.ubuntu_install(id:2550508, name: 'kristof22', wait: true, hero_install: true)!
+// cl.ubuntu_install(id: 2550253, name: 'kristof23', wait: true, hero_install: true)!

--- a/examples/virt/hetzner/hetzner_kristof3.vsh
+++ b/examples/virt/hetzner/hetzner_kristof3.vsh
@@ -8,33 +8,23 @@ import time
 import os
 import incubaid.herolib.core.playcmds
 
-// Server-specific configuration
-const server_name = 'kristof3'
-const server_whitelist = '2573047'
+name := 'kristof3'
 
-// Load credentials from environment variables
-// Source hetzner_env.sh before running: source examples/virt/hetzner/hetzner_env.sh
-hetzner_user := os.environ()['HETZNER_USER'] or {
+user := os.environ()['HETZNER_USER'] or {
 	println('HETZNER_USER not set')
 	exit(1)
 }
-
-hetzner_passwd := os.environ()['HETZNER_PASSWORD'] or {
+passwd := os.environ()['HETZNER_PASSWORD'] or {
 	println('HETZNER_PASSWORD not set')
-	exit(1)
-}
-
-hetzner_sshkey_name := os.environ()['HETZNER_SSHKEY_NAME'] or {
-	println('HETZNER_SSHKEY_NAME not set')
 	exit(1)
 }
 
 hs := '
 !!hetznermanager.configure
-	user:"${hetzner_user}"
-	whitelist:"${server_whitelist}"
-	password:"${hetzner_passwd}"
-	sshkey:"${hetzner_sshkey_name}"
+	user:"${user}"
+	whitelist:"2521602,2555487,2573047"
+	password:"${passwd}"
+	sshkey:"kristof"
 '
 
 println(hs)
@@ -52,7 +42,7 @@ mut cl := hetznermanager.get()!
 
 println(cl.servers_list()!)
 
-mut serverinfo := cl.server_info_get(name: server_name)!
+mut serverinfo := cl.server_info_get(name: name)!
 
 println(serverinfo)
 
@@ -65,7 +55,7 @@ println(serverinfo)
 
 // console.print_header('SSH login')
 
-cl.ubuntu_install(name: server_name, wait: true, hero_install: true)!
+cl.ubuntu_install(name: name, wait: true, hero_install: true)!
 // cl.ubuntu_install(name: 'kristof20', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550378, name: 'kristof21', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550508, name: 'kristof22', wait: true, hero_install: true)!

--- a/examples/virt/hetzner/hetzner_test1.vsh
+++ b/examples/virt/hetzner/hetzner_test1.vsh
@@ -8,33 +8,23 @@ import time
 import os
 import incubaid.herolib.core.playcmds
 
-// Server-specific configuration
-const server_name = 'test1'
-const server_whitelist = '2575034'
+name := 'test1'
 
-// Load credentials from environment variables
-// Source hetzner_env.sh before running: source examples/virt/hetzner/hetzner_env.sh
-hetzner_user := os.environ()['HETZNER_USER'] or {
+user := os.environ()['HETZNER_USER'] or {
 	println('HETZNER_USER not set')
 	exit(1)
 }
-
-hetzner_passwd := os.environ()['HETZNER_PASSWORD'] or {
+passwd := os.environ()['HETZNER_PASSWORD'] or {
 	println('HETZNER_PASSWORD not set')
-	exit(1)
-}
-
-hetzner_sshkey_name := os.environ()['HETZNER_SSHKEY_NAME'] or {
-	println('HETZNER_SSHKEY_NAME not set')
 	exit(1)
 }
 
 hs := '
 !!hetznermanager.configure
-	user:"${hetzner_user}"
-	whitelist:"${server_whitelist}"
-	password:"${hetzner_passwd}"
-	sshkey:"${hetzner_sshkey_name}"
+	user:"${user}"
+	whitelist:"2575034"
+	password:"${passwd}"
+	sshkey:"kristof"
 '
 
 println(hs)
@@ -52,7 +42,7 @@ mut cl := hetznermanager.get()!
 
 println(cl.servers_list()!)
 
-mut serverinfo := cl.server_info_get(name: server_name)!
+mut serverinfo := cl.server_info_get(name: name)!
 
 println(serverinfo)
 
@@ -65,7 +55,7 @@ println(serverinfo)
 
 // console.print_header('SSH login')
 
-cl.ubuntu_install(name: server_name, wait: true, hero_install: true)!
+cl.ubuntu_install(name: name, wait: true, hero_install: true)!
 // cl.ubuntu_install(name: 'kristof20', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550378, name: 'kristof21', wait: true, hero_install: true)!
 // cl.ubuntu_install(id:2550508, name: 'kristof22', wait: true, hero_install: true)!

--- a/examples/virt/hetzner/readme.md
+++ b/examples/virt/hetzner/readme.md
@@ -1,31 +1,20 @@
-# Hetzner Examples
 
-## Quick Start
+## to get started 
 
-### 1. Configure Environment Variables
-
-Copy `hetzner_env.sh` and fill in your credentials:
+make sure you have hero_secrets loaded
 
 ```bash
-export HETZNER_USER="your-robot-username"   # Hetzner Robot API username
-export HETZNER_PASSWORD="your-password"     # Hetzner Robot API password
-export HETZNER_SSHKEY_NAME="my-key"         # Name of SSH key registered in Hetzner
+hero git pull  https://git.threefold.info/despiegk/hero_secrets
+source ~/code/git.ourworld.tf/despiegk/hero_secrets/mysecrets.sh
 ```
 
-Each script has its own server name and whitelist ID defined at the top.
+## to e.g. install test1
 
-### 2. Run a Script
-
-```bash
-source hetzner_env.sh
-./hetzner_kristof2.vsh
+```
+~/code/github/incubaid/herolib/examples/virt/hetzner/hetzner_test1.vsh
 ```
 
-## SSH Keys
-
-The `HETZNER_SSHKEY_NAME` must be the **name** of an SSH key already registered in your Hetzner Robot account.
-
-Available keys in our Hetzner account:
+keys available:
 
 - hossnys (RSA 2048)
 - Jan De Landtsheer (ED25519 256)
@@ -33,25 +22,12 @@ Available keys in our Hetzner account:
 - kristof (ED25519 256)
 - maxime (ED25519 256)
 
-To add a new key, use `key_create` in your script or the Hetzner Robot web interface.
+## hetzner info
 
-## Alternative: Using hero_secrets
+get the login passwd from: 
 
-You can also use the shared secrets repository:
-
-```bash
-hero git pull https://git.threefold.info/despiegk/hero_secrets
-source ~/code/git.ourworld.tf/despiegk/hero_secrets/mysecrets.sh
-```
-
-## Troubleshooting
-
-### Get Robot API credentials
-
-Get your login credentials from: https://robot.hetzner.com/preferences/index
-
-### Test API access
+https://robot.hetzner.com/preferences/index
 
 ```bash
-curl -u "your-username:your-password" https://robot-ws.your-server.de/server
+curl -u "#ws+JdQtGCdL:..." https://robot-ws.your-server.de/server
 ```

--- a/lib/virt/hetznermanager/actions_key.v
+++ b/lib/virt/hetznermanager/actions_key.v
@@ -1,6 +1,7 @@
 module hetznermanager
 
 import incubaid.herolib.core.texttools
+import incubaid.herolib.ui.console
 
 pub struct SSHKey {
 pub mut:
@@ -75,4 +76,39 @@ pub fn (mut h HetznerManager) key_delete(name string) ! {
 		prefix:     'key/${key.fingerprint}'
 		dataformat: .urlencoded
 	)!
+}
+
+// Get SSH keys based on the sshkey specification mode:
+// - '*': returns all keys registered on Hetzner
+// - any other value: returns the key with that name (e.g., "kristof", "mahmoud")
+pub fn (mut h HetznerManager) get_keys_for_rescue() ![]SSHKey {
+	if h.sshkey == '*' {
+		// Return all keys registered on Hetzner
+		keys := h.keys_get()!
+		if keys.len == 0 {
+			return error('No SSH keys registered on Hetzner account')
+		}
+		console.print_debug('Using all ${keys.len} SSH keys from Hetzner')
+		return keys
+	} else {
+		// Use the specified key name
+		if !h.key_exists(h.sshkey) {
+			return error('SSH key "${h.sshkey}" not found on Hetzner. Available keys: ${h.keys_get()!.map(it.name).join(', ')}')
+		}
+		key := h.key_get(h.sshkey)!
+		console.print_debug('Using SSH key "${h.sshkey}" from Hetzner')
+		return [key]
+	}
+}
+
+// Get all public key data for the specified keys (for copying to authorized_keys)
+pub fn (mut h HetznerManager) get_pubkeys_data() ![]string {
+	keys := h.get_keys_for_rescue()!
+	mut pubkeys := []string{}
+	for key in keys {
+		if key.data.len > 0 {
+			pubkeys << key.data
+		}
+	}
+	return pubkeys
 }

--- a/lib/virt/hetznermanager/readme.md
+++ b/lib/virt/hetznermanager/readme.md
@@ -27,7 +27,24 @@ source hetzner_env.sh
 
 ### 1.2 SSH Key Configuration
 
-**Important:** The `sshkey` parameter expects the **name** of an SSH key already registered in your Hetzner Robot account, not the actual key content.
+The `sshkey` parameter supports two modes:
+
+- `"*"` - Use **all** SSH keys registered on your Hetzner account (recommended)
+- `"keyname"` - Use a specific key by name (e.g., `"kristof"`, `"mahmoud"`)
+
+**Example using all keys:**
+
+```hs
+!!hetznermanager.configure
+    sshkey: '*'  # All registered keys will have access
+```
+
+**Example using a specific key:**
+
+```hs
+!!hetznermanager.configure
+    sshkey: 'kristof'  # Only the 'kristof' key will have access
+```
 
 To register a new SSH key with Hetzner, use `key_create`:
 
@@ -35,13 +52,6 @@ To register a new SSH key with Hetzner, use `key_create`:
 !!hetznermanager.key_create
     key_name: 'my-laptop-key'
     data: 'ssh-ed25519 AAAAC3...'  # The actual public key content
-```
-
-Once registered, you can reference the key by name in `configure`:
-
-```hs
-!!hetznermanager.configure
-    sshkey: 'my-laptop-key'  # Reference the registered key by name
 ```
 
 ### 1.3 HeroScript Configuration
@@ -52,7 +62,7 @@ Once registered, you can reference the key by name in `configure`:
  user:"${HETZNER_USER}"
  password:"${HETZNER_PASSWORD}"
  whitelist:"1234567"             // Server ID(s) specific to your script
- sshkey:"${HETZNER_SSHKEY_NAME}"
+ sshkey:"*"                      // Use all keys, or specify a key name like "kristof"
 ```
 
 ## 2. Usage
@@ -101,7 +111,7 @@ HeroScript provides a simple, declarative way to execute server operations. You 
   * `user` (string): Hetzner Robot username.
   * `password` (string): Hetzner Robot password.
   * `whitelist` (string, optional): Comma-separated list of server IDs to restrict operations to.
-  * `sshkey` (string, optional): **Name** of an SSH key registered in your Hetzner account (not the key content).
+  * `sshkey` (string, optional): `"*"` for all keys, or a specific key name (e.g., `"kristof"`).
 * `!!hetznermanager.server_rescue`: Activates the rescue system.
   * `instance` (string, optional): The client instance to use (defaults to 'default').
   * `server_name` or `id` (string/int): Identifies the target server.

--- a/lib/virt/hetznermanager/rescue.v
+++ b/lib/virt/hetznermanager/rescue.v
@@ -83,18 +83,23 @@ fn (mut h HetznerManager) server_rescue_internal(args_ ServerRescueArgs) !Server
 	if serverinfo.rescue == false || args.reset {
 		console.print_header('server ${serverinfo.server_name} goes into rescue mode')
 
-		mykey := h.key_get(h.sshkey)!
-		mykeyfp := mykey.fingerprint
+		// Get SSH keys based on sshkey mode ('*', 'default', or specific key name)
+		keys := h.get_keys_for_rescue()!
 
-		// println("Using SSH key fingerprint: ${mykey} ${mykeyfp}")
+		// Build URL-encoded data with multiple authorized_key[] parameters
+		// Hetzner API expects: authorized_key[]=fp1&authorized_key[]=fp2&...
+		mut data_parts := ['os=linux']
+		for key in keys {
+			data_parts << 'authorized_key[]=${key.fingerprint}'
+		}
+		post_data := data_parts.join('&')
+
+		console.print_debug('Using ${keys.len} SSH key(s) for rescue mode')
 
 		mut conn := h.connection()!
 		rescue := conn.post_json_generic[RescueInfo](
 			prefix:     'boot/${serverinfo.server_number}/rescue'
-			params:     {
-				'os':             'linux'
-				'authorized_key': mykeyfp
-			}
+			data:       post_data
 			dict_key:   'rescue'
 			dataformat: .urlencoded
 		)!
@@ -184,9 +189,9 @@ pub fn (mut h HetznerManager) ubuntu_install(args ServerInstallArgs) !&builder.N
 		wait: true
 	)!
 
-	// Get the SSH key data to copy to the installed system
-	mykey := h.key_get(h.sshkey)!
-	ssh_pubkey := mykey.data
+	// Get all SSH public keys to copy to the installed system
+	pubkeys := h.get_pubkeys_data()!
+	ssh_pubkeys := pubkeys.join('\n')
 
 	mut b := builder.new()!
 	mut n := b.node_new(ipaddr: serverinfo.server_ip)!
@@ -225,14 +230,16 @@ if ! /root/.oldroot/nfs/install/installimage -a -n "${args.name}" ${rstr} -i /ro
 	exit 1
 fi
 
-# Copy SSH key to the installed system before rebooting
+# Copy SSH keys to the installed system before rebooting
 # After installimage, the new system is mounted at /mnt
-echo "Copying SSH key to installed system..."
+echo "Copying SSH keys to installed system..."
 mkdir -p /mnt/root/.ssh
 chmod 700 /mnt/root/.ssh
-echo "${ssh_pubkey}" > /mnt/root/.ssh/authorized_keys
+cat > /mnt/root/.ssh/authorized_keys << "EOF_SSH_KEYS"
+${ssh_pubkeys}
+EOF_SSH_KEYS
 chmod 600 /mnt/root/.ssh/authorized_keys
-echo "SSH key copied successfully"
+echo "SSH keys copied successfully"
 
 # Mark installation as complete before rebooting
 # sync to ensure marker file is written to disk before reboot


### PR DESCRIPTION
### Changes 

- Update example scripts with new server names and whitelists
- Refine examples documentation for using `secrets.sh` and Hetzner API credentials
- Clarify available SSH keys and how to add new ones
- Update the troubleshooting section with an API access testing example
- Add a function to retrieve all registered SSH keys
- Allow '*' to specify all keys, or a specific key name
- Update rescue mode to accept multiple authorized keys
- Copy all public SSH keys to the installed system
- Allow sshkey to accept "*" for all keys
- Update the Hetznermanager client documentation for the sshkey parameter usage
- Show example for using "*" and specific key names
- Update example with sshkey:"*" in HeroScript configuration

### Related Issues

- https://github.com/Incubaid/herolib/issues/212
- https://github.com/Incubaid/herolib/issues/210
