### PR TITLE
Development shelldocs

### DIFF
--- a/lib/builder/node_commands.v
+++ b/lib/builder/node_commands.v
@@ -217,7 +217,7 @@ pub fn (mut node Node) package_install(package Package) ! {
 		node.exec(cmd: 'apk install ${name}') or {
 			return error('could not install package:${package.name}\nerror:\n${err}')
 		}
-	} else if node.platform == PlatformType.alpine {
+	} else if node.platform == PlatformType.arch {
 		node.exec(cmd: 'pacman -Su ${name}') or {
 			return error('could not install package:${package.name}\nerror:\n${err}')
 		}

--- a/lib/osal/core/readme.md
+++ b/lib/osal/core/readme.md
@@ -21,7 +21,7 @@ Execute shell commands with fine-grained control and robust error handling.
     * `raise_error` (bool): Raise V error on failure (default: true).
     * `ignore_error` (bool): Do not raise error, just report.
     * `debug` (bool): Enable debug output.
-    * `shell` (bool): Execute in interactive shell.
+    * `shell` (bool): Execute in interactive shell. This transfers control to the new command, effectively exiting the current program.
     * `async` (bool): Run command asynchronously.
     * `runtime` (RunTime): Specify runtime (e.g., `.bash`, `.python`).
   * Returns `Job` struct with `status`, `output`, `error`, `exit_code`, etc.


### PR DESCRIPTION
Documents behavior of the `shell` parameter for exec. Fixes a small bug with platform discovery for node executors.