### PR TITLE
Configure the zinit sock path

### DIFF
--- a/examples/clients/zinit_rpc.vsh
+++ b/examples/clients/zinit_rpc.vsh
@@ -34,7 +34,7 @@ println('=== Zinit RPC Client Example ===\n')
 // installer.start()!
 
 // Create a new client
-mut client := zinit.new()!
+mut client := zinit.new(socket_path: '/var/run/zinit.sock')!
 
 println(client)
 

--- a/lib/clients/zinit/zinit_factory_.v
+++ b/lib/clients/zinit/zinit_factory_.v
@@ -17,11 +17,13 @@ pub mut:
 	name   string = 'default'
 	fromdb bool // will load from filesystem
 	create bool // default will not create if not exist
+	socket_path  string
 }
 
 pub fn new(args ArgsGet) !&ZinitRPC {
 	mut obj := ZinitRPC{
 		name: args.name
+		socket_path: args.socket_path
 	}
 	set(obj)!
 	return get(name: args.name)!

--- a/lib/clients/zinit/zinit_model.v
+++ b/lib/clients/zinit/zinit_model.v
@@ -1,27 +1,14 @@
 module zinit
 
 import incubaid.herolib.data.encoderhero
+import os
 
 pub const version = '0.0.0'
 const singleton = true
 const default = false
 
-// // Factory function to create a new ZinitRPC client instance
-// @[params]
-// pub struct NewClientArgs {
-// pub mut:
-// 	name        string = 'default'
-// 	socket_path string
-// }
-
-// pub fn new_client(args NewClientArgs) !&ZinitRPC {
-// 	mut client := ZinitRPC{
-// 		name:        args.name
-// 		socket_path: args.socket_path
-// 	}
-// 	client = obj_init(client)!
-// 	return &client
-// }
+// Common zinit socket paths to check
+const socket_paths = ['/var/run/zinit.sock', '/tmp/zinit.sock']
 
 @[heap]
 pub struct ZinitRPC {
@@ -35,9 +22,21 @@ pub mut:
 fn obj_init(mycfg_ ZinitRPC) !ZinitRPC {
 	mut mycfg := mycfg_
 	if mycfg.socket_path == '' {
-		mycfg.socket_path = '/tmp/zinit.sock'
+		// Auto-detect socket path by checking common locations
+		mycfg.socket_path = detect_socket_path()
 	}
 	return mycfg
+}
+
+// detect_socket_path tries common socket locations and returns the first one that exists
+fn detect_socket_path() string {
+	for path in socket_paths {
+		if os.exists(path) {
+			return path
+		}
+	}
+	// Default fallback if none found
+	return '/tmp/zinit.sock'
 }
 
 pub fn heroscript_loads(heroscript string) !ZinitRPC {


### PR DESCRIPTION
### Description

Auto-detect zinit socket path

- Add socket_path field to ZinitRPC struct
- Implement detect_socket_path function
- Use detect_socket_path in obj_init