### PR TITLE
feat(k8-apps): add Stalwart installer & refactor Element Chat, Gitea, CryptPad installers

### DIFF
--- a/examples/installers/k8s/element_chat.vsh
+++ b/examples/installers/k8s/element_chat.vsh
@@ -1,18 +1,18 @@
 #!/usr/bin/env -S v -n -w -gc none  -cc tcc -d use_openssl -enable-globals run
 
-import incubaid.herolib.installers.k8s.element_chat
+import incubaid.herolib.k8_apps.communication.k8_element_chat
 
 // This example demonstrates how to use the Element Chat installer.
 
 // 1. Create a new installer instance with specific hostnames.
 //    Replace 'matrixchattest' and 'elementchattest' with your desired hostnames.
 //    Note: Use only alphanumeric characters (no underscores or dashes).
-mut installer := element_chat.get(
-	name:   'kristof'
+mut installer := k8_element_chat.get(
+	name:   'demo'
 	create: true
 )!
 
-// element_chat.delete()!
+// k8_element_chat.delete()!
 
 // 2. Configure the installer (all settings are optional with sensible defaults)
 // installer.matrix_hostname = 'matrixchattest'

--- a/examples/installers/k8s/nextcloud.vsh
+++ b/examples/installers/k8s/nextcloud.vsh
@@ -28,6 +28,7 @@ installer.nextcloud_path = '/tmp/nextcloud-demo/nextcloud.yaml'
 installer.postgres_path = '/tmp/nextcloud-demo/postgres.yaml'
 installer.redis_path = '/tmp/nextcloud-demo/redis.yaml'
 installer.tfgw_path = '/tmp/nextcloud-demo/tfgw.yaml'
+installer.onlyoffice_path = '/tmp/nextcloud-demo/onlyoffice.yaml'
 
 // 3. Install Nextcloud
 // Note: The actual FQDN will be dynamically fetched from TFGW status after deployment

--- a/examples/installers/k8s/nextcloud.vsh
+++ b/examples/installers/k8s/nextcloud.vsh
@@ -1,0 +1,49 @@
+#!/usr/bin/env -S v -n -w -gc none  -cc tcc -d use_openssl -enable-globals run
+
+import incubaid.herolib.k8_apps.biz.k8_nextcloud
+
+// This example demonstrates how to use the Nextcloud installer with custom configuration.
+
+// 1. Create a new installer instance with custom settings
+mut installer := k8_nextcloud.get(
+	name:   'dimo'  // Short name to avoid TFGW 36-char limit
+	create: true
+)!
+
+// 2. Configure custom settings (testing data parsing)
+installer.nextcloud_storage_size = '15Gi'  // Custom Nextcloud storage
+installer.postgres_storage_size = '12Gi'   // Custom PostgreSQL storage
+
+// Custom admin credentials
+installer.admin_user = 'ncadmin'
+installer.admin_password = 'CustomAdminPass123!'
+
+// Custom database credentials
+installer.db_user = 'nc_dbuser'
+installer.db_password = 'CustomDbPass456!'
+
+// Custom YAML paths
+installer.secrets_path = '/tmp/nextcloud-demo/secrets.yaml'
+installer.nextcloud_path = '/tmp/nextcloud-demo/nextcloud.yaml'
+installer.postgres_path = '/tmp/nextcloud-demo/postgres.yaml'
+installer.redis_path = '/tmp/nextcloud-demo/redis.yaml'
+installer.tfgw_path = '/tmp/nextcloud-demo/tfgw.yaml'
+
+// 3. Install Nextcloud
+// Note: The actual FQDN will be dynamically fetched from TFGW status after deployment
+installer.install()!
+
+println('Nextcloud installation completed!')
+println('Configuration:')
+println('  - Nextcloud Storage: ${installer.nextcloud_storage_size}')
+println('  - PostgreSQL Storage: ${installer.postgres_storage_size}')
+println('  - Admin User: ${installer.admin_user}')
+println('  - Database: ${installer.db_name} (user: ${installer.db_user})')
+println('Custom paths:')
+println('  - Nextcloud YAML: ${installer.nextcloud_path}')
+println('  - PostgreSQL YAML: ${installer.postgres_path}')
+println('  - Redis YAML: ${installer.redis_path}')
+println('  - TFGW YAML: ${installer.tfgw_path}')
+
+// 4. To destroy the deployment:
+// installer.destroy()!

--- a/examples/installers/k8s/stalwart.vsh
+++ b/examples/installers/k8s/stalwart.vsh
@@ -1,0 +1,35 @@
+#!/usr/bin/env -S v -n -w -gc none  -cc tcc -d use_openssl -enable-globals run
+
+import incubaid.herolib.k8_apps.communication.stalwart
+
+// This example demonstrates how to use the Stalwart Mail Server installer.
+
+// 1. Create a new installer instance with custom settings
+mut installer := stalwart.get(
+	name:   'demo'  // Short name to avoid TFGW 36-char limit
+	create: true
+)!
+
+// 2. Configure custom settings (optional - all have sensible defaults)
+// installer.hostname = 'mymail'  // Custom hostname for TFGW
+// installer.admin_user = 'admin'
+// installer.admin_password = 'mysecurepassword'
+// installer.storage_size = '50Gi'
+// installer.log_level = 'debug'
+
+// 3. Install Stalwart Mail Server
+//    This will deploy:
+//    - TFGW for HTTPS access to web UI/JMAP/CalDAV/CardDAV
+//    - Stalwart deployment with ConfigMap and PVC
+//    - LoadBalancer service for mail ports (SMTP/IMAP/POP3/Sieve)
+installer.install()!
+
+println('Stalwart Mail Server installation completed!')
+println('Configuration:')
+println('  - Hostname: ${installer.hostname}')
+println('  - Admin User: ${installer.admin_user}')
+println('  - Storage Size: ${installer.storage_size}')
+println('  - Log Level: ${installer.log_level}')
+
+// 4. To destroy the deployment:
+// installer.destroy()!

--- a/lib/k8_apps/biz/k8_cryptpad/cryptpad_model.v
+++ b/lib/k8_apps/biz/k8_cryptpad/cryptpad_model.v
@@ -33,9 +33,16 @@ pub mut:
 // your checking & initialization code if needed
 fn obj_init(mycfg_ CryptpadServer) !CryptpadServer {
 	mut mycfg := mycfg_
+
+	if mycfg.name == '' {
+		mycfg.name = 'cryptpad'
+	}
+
+	// Use core name_fix for consistent name handling
+	mycfg.name = core.name_fix(mycfg.name)
 	
-	// Set default namespace if not provided
-	namespace := '${mycfg.name}-cryptpad-namespace'
+	// Set default namespace (no dashes to avoid name_fix issues)
+	namespace := '${mycfg.name}cryptpadns'
 	
 	mycfg.k8app = core.k8app(
 		app_name: 'cryptpad'

--- a/lib/k8_apps/biz/k8_nextcloud/.heroscript
+++ b/lib/k8_apps/biz/k8_nextcloud/.heroscript
@@ -1,0 +1,12 @@
+
+!!hero_code.generate_installer
+    name:''
+    classname:'NextCloud'
+    singleton:0
+    templates:1
+    default:1
+    title:''
+    supported_platforms:''
+    startupmanager:0
+	hasconfig:1
+    build:0

--- a/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_actions.v
+++ b/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_actions.v
@@ -1,0 +1,277 @@
+module k8_nextcloud
+
+import incubaid.herolib.ui.console
+import incubaid.herolib.installers.ulist
+import incubaid.herolib.k8_apps.core
+import time
+
+//////////////////// following actions are not specific to instance of the object
+
+// checks if a certain version or above is installed
+pub fn installed() !bool {
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+
+	// Try to get the nextcloud deployment
+	deployments := k8s.get_deployments(k8app.namespace) or {
+		// If we can't get deployments, it's not running
+		return false
+	}
+
+	// Check if nextcloud deployment exists
+	for deployment in deployments {
+		if deployment.name == 'nextcloud' {
+			return true
+		}
+	}
+
+	return false
+}
+
+// get the Upload List of the files
+fn ulist_get() !ulist.UList {
+	// optionally build a UList which is all paths which are result of building, is then used e.g. in upload
+	return ulist.UList{}
+}
+
+// uploads to S3 server if configured
+fn upload() ! {
+	// installers.upload(
+	//     cmdname: 'nextcloud'
+	//     source: '${gitpath}/target/x86_64-unknown-linux-musl/release/nextcloud'
+	// )!
+}
+
+fn install() ! {
+	console.print_header('Installing Nextcloud...')
+
+	// Get installer config to access namespace
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+
+	// 1. Check for dependencies
+	console.print_info('Checking for kubectl...')
+	core.kubectl_installed(mut k8s)!
+	console.print_info('kubectl is installed and configured.')
+
+	// 2. Generate and apply TFGW YAML first
+	configure_tfgw()!
+	console.print_info('Applying TFGW YAML file to the cluster...')
+	res_tfgw := k8s.apply_yaml(installer.tfgw_path)!
+	if !res_tfgw.success {
+		return error('Failed to apply tfgw.yaml: ${res_tfgw.stderr}')
+	}
+	console.print_info('TFGW YAML file applied successfully.')
+
+	// 3. Get the actual FQDN from TFGW status
+	fqdn := core.get_tfgw_fqdn(tfgw_name: 'nextcloud', namespace: k8app.namespace, k8s: k8s)!
+
+	// 4. Generate remaining YAML files with the actual FQDN
+	configure_with_fqdn(fqdn)!
+
+	// 5. Apply Secrets YAML (must be before PostgreSQL)
+	console.print_info('Applying Secrets YAML file to the cluster...')
+	res_secrets := k8s.apply_yaml(installer.secrets_path)!
+	if !res_secrets.success {
+		return error('Failed to apply secrets.yaml: ${res_secrets.stderr}')
+	}
+	console.print_info('Secrets YAML file applied successfully.')
+
+	// 6. Apply PostgreSQL YAML
+	console.print_info('Applying PostgreSQL YAML file to the cluster...')
+	res_postgres := k8s.apply_yaml(installer.postgres_path)!
+	if !res_postgres.success {
+		return error('Failed to apply postgres.yaml: ${res_postgres.stderr}')
+	}
+	console.print_info('PostgreSQL YAML file applied successfully.')
+
+	// 7. Verify PostgreSQL pod is ready
+	verify_postgres_ready(namespace: k8app.namespace)!
+
+	// 8. Apply Redis YAML
+	console.print_info('Applying Redis YAML file to the cluster...')
+	res_redis := k8s.apply_yaml(installer.redis_path)!
+	if !res_redis.success {
+		return error('Failed to apply redis.yaml: ${res_redis.stderr}')
+	}
+	console.print_info('Redis YAML file applied successfully.')
+
+	// 9. Verify Redis deployment is ready
+	verify_redis_ready(namespace: k8app.namespace)!
+
+	// 10. Apply Nextcloud YAML
+	console.print_info('Applying Nextcloud YAML file to the cluster...')
+	res_nextcloud := k8s.apply_yaml(installer.nextcloud_path)!
+	if !res_nextcloud.success {
+		return error('Failed to apply nextcloud.yaml: ${res_nextcloud.stderr}')
+	}
+	console.print_info('Nextcloud YAML file applied successfully.')
+
+	// 11. Verify deployment is running
+	console.print_info('Verifying deployment status...')
+	mut is_running := false
+	for i in 0 .. core.max_deployment_retries {
+		if installed()! {
+			is_running = true
+			break
+		}
+		console.print_info('Waiting for Nextcloud deployment to be ready... (${i + 1}/${core.max_deployment_retries})')
+		time.sleep(core.deployment_check_interval_seconds * time.second)
+	}
+
+	if !is_running {
+		return error('Nextcloud deployment failed to start.')
+	}
+
+	// 12. Verify Nextcloud is fully installed using occ status
+	console.print_info('Verifying Nextcloud installation status...')
+	verify_nextcloud_installed(namespace: k8app.namespace)!
+
+	console.print_header('Nextcloud installation successful!')
+	console.print_header('You can access Nextcloud at https://${fqdn}')
+	console.print_info('Admin user: ${installer.admin_user}')
+	console.print_info('Admin password: ${installer.admin_password}')
+}
+
+// params for verifying postgres pod is ready
+@[params]
+struct VerifyPostgresReady {
+pub mut:
+	namespace string // namespace name for postgres pod
+}
+
+// Function for verifying postgres pod is ready
+fn verify_postgres_ready(args VerifyPostgresReady) ! {
+	console.print_info('Verifying PostgreSQL StatefulSet is ready...')
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+	mut is_ready := false
+
+	for i in 0 .. core.max_deployment_retries {
+		// Check if postgres statefulset pod exists and is running
+		result := k8s.kubectl_exec(
+			command: 'get pod nextcloud-postgres-0 -n ${args.namespace} -o jsonpath="{.status.phase}"'
+		) or {
+			console.print_info('Waiting for PostgreSQL pod to be created... (${i + 1}/${core.max_deployment_retries})')
+			time.sleep(core.deployment_check_interval_seconds * time.second)
+			continue
+		}
+
+		if result.success && result.stdout == 'Running' {
+			is_ready = true
+			break
+		}
+		console.print_info('Waiting for PostgreSQL pod to be ready... (${i + 1}/${core.max_deployment_retries})')
+		time.sleep(core.deployment_check_interval_seconds * time.second)
+	}
+
+	if !is_ready {
+		console.print_stderr('PostgreSQL pod failed to become ready.')
+		return error('PostgreSQL pod failed to become ready.')
+	}
+	console.print_info('PostgreSQL pod is ready.')
+}
+
+// params for verifying redis deployment is ready
+@[params]
+struct VerifyRedisReady {
+pub mut:
+	namespace string // namespace name for redis deployment
+}
+
+// Function for verifying redis deployment is ready
+fn verify_redis_ready(args VerifyRedisReady) ! {
+	console.print_info('Verifying Redis deployment is ready...')
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+	mut is_ready := false
+
+	for i in 0 .. core.max_deployment_retries {
+		// Check if redis deployment exists
+		deployments := k8s.get_deployments(args.namespace) or {
+			console.print_info('Waiting for Redis deployment to be created... (${i + 1}/${core.max_deployment_retries})')
+			time.sleep(core.deployment_check_interval_seconds * time.second)
+			continue
+		}
+
+		for deployment in deployments {
+			if deployment.name == 'nextcloud-redis' {
+				is_ready = true
+				break
+			}
+		}
+
+		if is_ready {
+			break
+		}
+
+		console.print_info('Waiting for Redis deployment to be ready... (${i + 1}/${core.max_deployment_retries})')
+		time.sleep(core.deployment_check_interval_seconds * time.second)
+	}
+
+	if !is_ready {
+		console.print_stderr('Redis deployment failed to become ready.')
+		return error('Redis deployment failed to become ready.')
+	}
+	console.print_info('Redis deployment is ready.')
+}
+
+// params for verifying nextcloud is installed
+@[params]
+struct VerifyNextcloudInstalled {
+pub mut:
+	namespace string // namespace name for nextcloud
+}
+
+// Verify Nextcloud is fully installed using occ status
+fn verify_nextcloud_installed(args VerifyNextcloudInstalled) ! {
+	console.print_info('Checking Nextcloud installation status via occ...')
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+	mut is_installed := false
+
+	// Give Nextcloud time to initialize and install
+	for i in 0 .. core.max_deployment_retries * 2 {
+		// Run occ status to check installation
+		result := k8s.kubectl_exec(
+			command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ status --output=json"'
+		) or {
+			console.print_info('Waiting for Nextcloud to initialize... (${i + 1}/${core.max_deployment_retries * 2})')
+			time.sleep(core.deployment_check_interval_seconds * time.second)
+			continue
+		}
+
+		if result.success && result.stdout.contains('"installed":true') {
+			is_installed = true
+			console.print_info('Nextcloud occ status: installed = true')
+			break
+		} else if result.success && result.stdout.contains('"installed":false') {
+			console.print_info('Nextcloud not yet installed, waiting... (${i + 1}/${core.max_deployment_retries * 2})')
+			time.sleep(core.deployment_check_interval_seconds * time.second)
+		} else {
+			console.print_info('Waiting for Nextcloud installation... (${i + 1}/${core.max_deployment_retries * 2})')
+			time.sleep(core.deployment_check_interval_seconds * time.second)
+		}
+	}
+
+	if !is_installed {
+		console.print_stderr('Nextcloud installation check timed out.')
+		console.print_info('Note: Nextcloud may still be installing. You can manually complete setup at the web interface.')
+		console.print_info('To check manually: kubectl -n ${args.namespace} exec deploy/nextcloud -- su -s /bin/bash www-data -c "php /var/www/html/occ status"')
+	} else {
+		console.print_info('Nextcloud is fully installed and ready.')
+	}
+}
+
+fn destroy() ! {
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+	
+	core.destroy_namespace(mut k8s, k8app.namespace)!
+}

--- a/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_actions.v
+++ b/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_actions.v
@@ -68,8 +68,18 @@ fn install() ! {
 	// 3. Get the actual FQDN from TFGW status
 	fqdn := core.get_tfgw_fqdn(tfgw_name: 'nextcloud', namespace: k8app.namespace, k8s: k8s)!
 
-	// 4. Generate remaining YAML files with the actual FQDN
-	configure_with_fqdn(fqdn)!
+	// 4. Determine OnlyOffice FQDN (will be fetched later after OnlyOffice TFGW is applied)
+	// For now, generate it from the same domain pattern but with 'office' suffix
+	onlyoffice_fqdn := if installer.onlyoffice_enabled {
+		// Extract domain from fqdn (e.g., gent02.grid.tf from nextclouddimo.gent02.grid.tf)
+		domain := fqdn.all_after_first('.')
+		'${k8app.hostname}office.${domain}'
+	} else {
+		''
+	}
+
+	// 5. Generate remaining YAML files with the actual FQDNs
+	configure_with_fqdn(fqdn, onlyoffice_fqdn)!
 
 	// 5. Apply Secrets YAML (must be before PostgreSQL)
 	console.print_info('Applying Secrets YAML file to the cluster...')
@@ -109,7 +119,20 @@ fn install() ! {
 	}
 	console.print_info('Nextcloud YAML file applied successfully.')
 
-	// 11. Verify deployment is running
+	// 11. Apply OnlyOffice YAML if enabled
+	if installer.onlyoffice_enabled {
+		console.print_info('Applying OnlyOffice YAML file to the cluster...')
+		res_onlyoffice := k8s.apply_yaml(installer.onlyoffice_path)!
+		if !res_onlyoffice.success {
+			return error('Failed to apply onlyoffice.yaml: ${res_onlyoffice.stderr}')
+		}
+		console.print_info('OnlyOffice YAML file applied successfully.')
+		
+		// Verify OnlyOffice deployment
+		verify_onlyoffice_ready(namespace: k8app.namespace)!
+	}
+
+	// 12. Verify Nextcloud deployment is running
 	console.print_info('Verifying deployment status...')
 	mut is_running := false
 	for i in 0 .. core.max_deployment_retries {
@@ -125,14 +148,31 @@ fn install() ! {
 		return error('Nextcloud deployment failed to start.')
 	}
 
-	// 12. Verify Nextcloud is fully installed using occ status
+	// 13. Verify Nextcloud is fully installed using occ status
 	console.print_info('Verifying Nextcloud installation status...')
 	verify_nextcloud_installed(namespace: k8app.namespace)!
+
+	// 14. Configure OnlyOffice connector in Nextcloud if enabled
+	if installer.onlyoffice_enabled {
+		// Get actual OnlyOffice FQDN from TFGW (it was deployed in step 11)
+		actual_onlyoffice_fqdn := core.get_tfgw_fqdn(tfgw_name: 'onlyoffice', namespace: k8app.namespace, k8s: k8s)!
+		
+		configure_onlyoffice_connector(
+			namespace:       k8app.namespace
+			jwt_secret:      installer.onlyoffice_jwt_secret
+			public_url:      'https://${actual_onlyoffice_fqdn}'
+			internal_url:    'http://onlyoffice'
+		)!
+	}
+
 
 	console.print_header('Nextcloud installation successful!')
 	console.print_header('You can access Nextcloud at https://${fqdn}')
 	console.print_info('Admin user: ${installer.admin_user}')
 	console.print_info('Admin password: ${installer.admin_password}')
+	if installer.onlyoffice_enabled {
+		console.print_info('OnlyOffice integration: Enabled')
+	}
 }
 
 // params for verifying postgres pod is ready
@@ -267,6 +307,144 @@ fn verify_nextcloud_installed(args VerifyNextcloudInstalled) ! {
 		console.print_info('Nextcloud is fully installed and ready.')
 	}
 }
+
+// params for verifying OnlyOffice is ready
+@[params]
+struct VerifyOnlyOfficeReady {
+pub mut:
+	namespace string
+}
+
+// Verify OnlyOffice deployment is ready
+fn verify_onlyoffice_ready(args VerifyOnlyOfficeReady) ! {
+	console.print_info('Verifying OnlyOffice deployment is ready...')
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+	mut is_ready := false
+
+	for i in 0 .. core.max_deployment_retries {
+		deployments := k8s.get_deployments(args.namespace) or {
+			console.print_info('Waiting for OnlyOffice deployment to be created... (${i + 1}/${core.max_deployment_retries})')
+			time.sleep(core.deployment_check_interval_seconds * time.second)
+			continue
+		}
+
+		for deployment in deployments {
+			if deployment.name == 'onlyoffice' {
+				is_ready = true
+				break
+			}
+		}
+
+		if is_ready {
+			break
+		}
+
+		console.print_info('Waiting for OnlyOffice deployment to be ready... (${i + 1}/${core.max_deployment_retries})')
+		time.sleep(core.deployment_check_interval_seconds * time.second)
+	}
+
+	if !is_ready {
+		console.print_stderr('OnlyOffice deployment failed to become ready.')
+		return error('OnlyOffice deployment failed to become ready.')
+	}
+	console.print_info('OnlyOffice deployment is ready.')
+}
+
+// params for configuring OnlyOffice connector
+@[params]
+struct ConfigureOnlyOfficeConnector {
+pub mut:
+	namespace    string
+	jwt_secret   string
+	public_url   string  // Public URL for browser access (https://...)
+	internal_url string  // Internal URL for server-side requests (http://onlyoffice)
+}
+
+// Configure Nextcloud to connect to OnlyOffice
+fn configure_onlyoffice_connector(args ConfigureOnlyOfficeConnector) ! {
+	console.print_info('Configuring OnlyOffice connector in Nextcloud...')
+	installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+
+	// Install and enable OnlyOffice app
+	console.print_info('Installing OnlyOffice app in Nextcloud...')
+	install_result := k8s.kubectl_exec(
+		command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ app:install onlyoffice"'
+	) or {
+		console.print_info('OnlyOffice app may already be installed, enabling...')
+		k8s.kubectl_exec(
+			command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ app:enable onlyoffice"'
+		) or {
+			console.print_stderr('Failed to enable OnlyOffice app.')
+			return error('Failed to enable OnlyOffice app.')
+		}
+		return
+	}
+
+	if !install_result.success && !install_result.stdout.contains('already installed') {
+		console.print_info('Enabling OnlyOffice app...')
+		k8s.kubectl_exec(
+			command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ app:enable onlyoffice"'
+		) or {
+			console.print_stderr('Failed to enable OnlyOffice app.')
+			return error('Failed to enable OnlyOffice app.')
+		}
+	}
+
+	// Configure OnlyOffice public server URL (for browser access)
+	console.print_info('Configuring OnlyOffice public URL: ${args.public_url}')
+	k8s.kubectl_exec(
+		command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value=${args.public_url}"'
+	) or {
+		console.print_stderr('Failed to configure OnlyOffice server URL.')
+		return error('Failed to configure OnlyOffice server URL.')
+	}
+
+	// Configure OnlyOffice internal URL (for server-side requests from Nextcloud to OnlyOffice)
+	console.print_info('Configuring OnlyOffice internal URL: ${args.internal_url}')
+	k8s.kubectl_exec(
+		command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ config:app:set onlyoffice DocumentServerInternalUrl --value=${args.internal_url}/"'
+	) or {
+		console.print_stderr('Failed to configure OnlyOffice internal URL.')
+		return error('Failed to configure OnlyOffice internal URL.')
+	}
+
+	// Configure Storage URL for OnlyOffice → Nextcloud internal requests
+	console.print_info('Configuring OnlyOffice StorageUrl (Nextcloud internal): http://nextcloud-web/')
+	k8s.kubectl_exec(
+		command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ config:app:set onlyoffice StorageUrl --value=http://nextcloud-web/"'
+	) or {
+		console.print_stderr('Failed to configure OnlyOffice StorageUrl.')
+		return error('Failed to configure OnlyOffice StorageUrl.')
+	}
+
+	// Configure JWT secret
+	console.print_info('Configuring OnlyOffice JWT secret...')
+	k8s.kubectl_exec(
+		command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ config:app:set onlyoffice jwt_secret --value=${args.jwt_secret}"'
+	) or {
+		console.print_stderr('Failed to configure OnlyOffice JWT secret.')
+		return error('Failed to configure OnlyOffice JWT secret.')
+	}
+
+	// Configure JWT header (must match ONLYOFFICE env JWT_HEADER)
+	console.print_info('Configuring OnlyOffice JWT header: Authorization')
+	k8s.kubectl_exec(
+		command: 'exec deploy/nextcloud -n ${args.namespace} -- su -s /bin/bash www-data -c "php /var/www/html/occ config:app:set onlyoffice jwt_header --value=Authorization"'
+	) or {
+		console.print_stderr('Failed to configure OnlyOffice JWT header.')
+		return error('Failed to configure OnlyOffice JWT header.')
+	}
+
+	console.print_info('OnlyOffice connector configured successfully.')
+	console.print_info('  Public URL (browsers): ${args.public_url}')
+	console.print_info('  Internal URL (NC→OO): ${args.internal_url}')
+	console.print_info('  Storage URL (OO→NC): http://nextcloud-web/')
+}
+
 
 fn destroy() ! {
 	installer := get()!

--- a/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_factory_.v
+++ b/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_factory_.v
@@ -1,0 +1,184 @@
+module k8_nextcloud
+
+import incubaid.herolib.core.base
+import incubaid.herolib.core.playbook { PlayBook }
+import incubaid.herolib.ui.console
+import json
+
+__global (
+	k8_nextcloud_global  map[string]&NextcloudK8SInstaller
+	k8_nextcloud_default string
+)
+
+/////////FACTORY
+
+@[params]
+pub struct ArgsGet {
+pub mut:
+	name   string = k8_nextcloud_default
+	fromdb bool // will load from filesystem
+	create bool // default will not create if not exist
+}
+
+pub fn new(args ArgsGet) !&NextcloudK8SInstaller {
+	mut obj := NextcloudK8SInstaller{
+		name: args.name
+	}
+	set(obj)!
+	return get(name: args.name)!
+}
+
+pub fn get(args ArgsGet) !&NextcloudK8SInstaller {
+	mut context := base.context()!
+	k8_nextcloud_default = args.name
+	if args.fromdb || args.name !in k8_nextcloud_global {
+		mut r := context.redis()!
+		if r.hexists('context:k8_nextcloud', args.name)! {
+			data := r.hget('context:k8_nextcloud', args.name)!
+			if data.len == 0 {
+				print_backtrace()
+				return error('NextcloudK8SInstaller with name: ${args.name} does not exist, prob bug.')
+			}
+			mut obj := json.decode(NextcloudK8SInstaller, data)!
+			set_in_mem(obj)!
+		} else {
+			if args.create {
+				new(args)!
+			} else {
+				print_backtrace()
+				return error("NextcloudK8SInstaller with name '${args.name}' does not exist")
+			}
+		}
+		return get(name: args.name)! // no longer from db nor create
+	}
+	return k8_nextcloud_global[args.name] or {
+		print_backtrace()
+		return error('could not get config for k8_nextcloud with name:${args.name}')
+	}
+}
+
+// register the config for the future
+pub fn set(o NextcloudK8SInstaller) ! {
+	mut o2 := set_in_mem(o)!
+	k8_nextcloud_default = o2.name
+	mut context := base.context()!
+	mut r := context.redis()!
+	r.hset('context:k8_nextcloud', o2.name, json.encode(o2))!
+}
+
+// does the config exists?
+pub fn exists(args ArgsGet) !bool {
+	mut context := base.context()!
+	mut r := context.redis()!
+	return r.hexists('context:k8_nextcloud', args.name)!
+}
+
+pub fn delete(args ArgsGet) ! {
+	mut context := base.context()!
+	mut r := context.redis()!
+	r.hdel('context:k8_nextcloud', args.name)!
+}
+
+@[params]
+pub struct ArgsList {
+pub mut:
+	fromdb bool // will load from filesystem
+}
+
+// if fromdb set: load from filesystem, and not from mem, will also reset what is in mem
+pub fn list(args ArgsList) ![]&NextcloudK8SInstaller {
+	mut res := []&NextcloudK8SInstaller{}
+	mut context := base.context()!
+	if args.fromdb {
+		// reset what is in mem
+		k8_nextcloud_global = map[string]&NextcloudK8SInstaller{}
+		k8_nextcloud_default = ''
+	}
+	if args.fromdb {
+		mut r := context.redis()!
+		mut l := r.hkeys('context:k8_nextcloud')!
+
+		for name in l {
+			res << get(name: name, fromdb: true)!
+		}
+		return res
+	} else {
+		// load from memory
+		for _, client in k8_nextcloud_global {
+			res << client
+		}
+	}
+	return res
+}
+
+// only sets in mem, does not set as config
+fn set_in_mem(o NextcloudK8SInstaller) !NextcloudK8SInstaller {
+	mut o2 := obj_init(o)!
+	k8_nextcloud_global[o2.name] = &o2
+	k8_nextcloud_default = o2.name
+	return o2
+}
+
+pub fn play(mut plbook PlayBook) ! {
+	if !plbook.exists(filter: 'k8_nextcloud.') {
+		return
+	}
+	mut install_actions := plbook.find(filter: 'k8_nextcloud.configure')!
+	if install_actions.len > 0 {
+		for mut install_action in install_actions {
+			heroscript := install_action.heroscript()
+			mut obj2 := heroscript_loads(heroscript)!
+			set(obj2)!
+			install_action.done = true
+		}
+	}
+	mut other_actions := plbook.find(filter: 'k8_nextcloud.')!
+	for mut other_action in other_actions {
+		if other_action.name in ['destroy', 'install'] {
+			mut p := other_action.params
+			reset := p.get_default_false('reset')
+			if other_action.name == 'destroy' || reset {
+				console.print_debug('install action k8_nextcloud.destroy')
+				destroy()!
+			}
+			if other_action.name == 'install' {
+				console.print_debug('install action k8_nextcloud.install')
+				install()!
+			}
+		}
+		other_action.done = true
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////# LIVE CYCLE MANAGEMENT FOR INSTALLERS ///////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// load from disk and make sure is properly intialized
+pub fn (mut self NextcloudK8SInstaller) reload() ! {
+	self = obj_init(self)!
+	set(self)!
+}
+
+@[params]
+pub struct InstallArgs {
+pub mut:
+	reset bool
+}
+
+pub fn (mut self NextcloudK8SInstaller) install(args InstallArgs) ! {
+	switch(self.name)
+	if args.reset || (!installed()!) {
+		install()!
+	}
+}
+
+pub fn (mut self NextcloudK8SInstaller) destroy() ! {
+	switch(self.name)
+	destroy()!
+}
+
+// switch instance to be used for k8_nextcloud
+pub fn switch(name string) {
+	k8_nextcloud_default = name
+}

--- a/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_model.v
+++ b/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_model.v
@@ -1,0 +1,212 @@
+module k8_nextcloud
+
+import incubaid.herolib.ui.console
+import incubaid.herolib.data.encoderhero
+import incubaid.herolib.virt.kubernetes
+import incubaid.herolib.core.pathlib
+import incubaid.herolib.k8_apps.core
+import strings
+import crypto.rand
+
+pub const version = '0.0.0'
+const singleton = false
+const default = false
+
+struct ConfigValues {
+pub mut:
+	hostname                string
+	backends                string
+	namespace               string
+	nextcloud_storage_size  string
+	postgres_storage_size   string
+	admin_user              string
+	admin_password          string
+	db_name                 string
+	db_user                 string
+	db_password             string
+	postgres_host           string
+	redis_host              string
+	fqdn                    string
+}
+
+@[heap]
+pub struct NextcloudK8SInstaller {
+pub mut:
+	name string = 'nextcloud'
+	
+	// K8s integration
+	k8app ?core.K8App
+	
+	// Storage configuration
+	nextcloud_storage_size string = '10Gi'
+	postgres_storage_size  string = '10Gi'
+	
+	// Admin credentials
+	admin_user     string = 'admin'
+	admin_password string  // Auto-generated if empty
+	
+	// Database configuration
+	db_name     string = 'nextcloud'
+	db_user     string = 'ncuser'
+	db_password string  // Auto-generated if empty
+	
+	// Redis (no auth by default)
+	redis_host string = 'nextcloud-redis'
+	
+	// YAML output paths
+	secrets_path   string = '/tmp/nextcloud/secrets.yaml'
+	postgres_path  string = '/tmp/nextcloud/postgres.yaml'
+	redis_path     string = '/tmp/nextcloud/redis.yaml'
+	tfgw_path      string = '/tmp/nextcloud/tfgw.yaml'
+	nextcloud_path string = '/tmp/nextcloud/nextcloud.yaml'
+	
+	// Internal
+	kube_client kubernetes.KubeClient @[skip]
+}
+
+// Generate a secure random password
+fn generate_password() string {
+	bytes := rand.bytes(24) or { return 'changeme' }
+	return bytes.hex()
+}
+
+// your checking & initialization code if needed
+fn obj_init(mycfg_ NextcloudK8SInstaller) !NextcloudK8SInstaller {
+	mut mycfg := mycfg_
+	
+	if mycfg.name == '' {
+		mycfg.name = 'nextcloud'
+	}
+	
+	// Replace dashes, dots, and underscores with nothing in name
+	mycfg.name = mycfg.name.replace('_', '')
+	mycfg.name = mycfg.name.replace('-', '')
+	mycfg.name = mycfg.name.replace('.', '')
+	
+	// Initialize k8app
+	namespace := '${mycfg.name}-nextcloud-namespace'
+	mycfg.k8app = core.k8app(
+		app_name: 'nextcloud'
+		app_instance: mycfg.name
+		namespace: namespace
+	)!
+	
+	// Auto-generate passwords if not provided
+	if mycfg.admin_password == '' {
+		mycfg.admin_password = generate_password()
+		console.print_info('Generated admin password: ${mycfg.admin_password}')
+	}
+	
+	if mycfg.db_password == '' {
+		mycfg.db_password = generate_password()
+		console.print_info('Generated database password: ${mycfg.db_password}')
+	}
+	
+	mycfg.kube_client = kubernetes.get(create: true)!
+	k8app := mycfg.k8app or { return error('k8app not initialized') }
+	mycfg.kube_client.config.namespace = k8app.namespace
+	
+	return mycfg
+}
+
+// Generate TFGW YAML only (first step - before we know the FQDN)
+fn configure_tfgw() ! {
+	mut installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+	
+	master_ips := core.get_master_node_ips(mut k8s)!
+	console.print_info('Master node IPs: ${master_ips}')
+	
+	mut backends_str_builder := strings.new_builder(100)
+	for ip in master_ips {
+		backends_str_builder.writeln('    - "http://[${ip}]:80"')
+	}
+	
+	console.print_info('Generating TFGW configuration file...')
+	
+	// Create config_values for TFGW template only
+	mut config_values := ConfigValues{
+		hostname:  k8app.hostname
+		backends:  backends_str_builder.str()
+		namespace: k8app.namespace
+	}
+	
+	// Ensure output directory exists
+	mut tfgw_path_obj := pathlib.get(installer.tfgw_path)
+	output_dir := tfgw_path_obj.path_dir()
+	_ := pathlib.get_dir(path: output_dir, create: true)!
+	
+	// Generate TFGW YAML
+	tfgw_yaml := $tmpl('./templates/tfgw.yaml')
+	mut tfgw_path := pathlib.get_file(
+		path:   installer.tfgw_path
+		create: true
+		check:  true
+	)!
+	tfgw_path.write(tfgw_yaml)!
+	console.print_info('TFGW configuration file generated.')
+}
+
+// Generate remaining YAML files using the actual FQDN from TFGW
+fn configure_with_fqdn(fqdn string) ! {
+	mut installer := get()!
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	
+	console.print_info('Generating configuration files with FQDN: ${fqdn}...')
+	
+	// Create config_values for template generation with actual FQDN
+	mut config_values := ConfigValues{
+		hostname:               k8app.hostname
+		backends:               ''
+		namespace:              k8app.namespace
+		nextcloud_storage_size: installer.nextcloud_storage_size
+		postgres_storage_size:  installer.postgres_storage_size
+		admin_user:             installer.admin_user
+		admin_password:         installer.admin_password
+		db_name:                installer.db_name
+		db_user:                installer.db_user
+		db_password:            installer.db_password
+		postgres_host:          'nextcloud-postgres'
+		redis_host:             installer.redis_host
+		fqdn:                   fqdn
+	}
+	
+	// Generate Secrets YAML
+	secrets_yaml := $tmpl('./templates/secrets.yaml')
+	mut secrets_path := pathlib.get_file(
+		path:   installer.secrets_path
+		create: true
+		check:  true
+	)!
+	secrets_path.write(secrets_yaml)!
+	console.print_info('Secrets configuration file generated.')
+	
+	// Generate PostgreSQL YAML
+	postgres_yaml := $tmpl('./templates/postgres.yaml')
+	mut postgres_path := pathlib.get_file(path: installer.postgres_path, create: true)!
+	postgres_path.write(postgres_yaml)!
+	console.print_info('PostgreSQL configuration file generated.')
+	
+	// Generate Redis YAML
+	redis_yaml := $tmpl('./templates/redis.yaml')
+	mut redis_path := pathlib.get_file(path: installer.redis_path, create: true)!
+	redis_path.write(redis_yaml)!
+	console.print_info('Redis configuration file generated.')
+	
+	// Generate Nextcloud YAML
+	nextcloud_yaml := $tmpl('./templates/nextcloud.yaml')
+	mut nextcloud_path := pathlib.get_file(path: installer.nextcloud_path, create: true)!
+	nextcloud_path.write(nextcloud_yaml)!
+	console.print_info('Nextcloud configuration file generated.')
+	
+	console.print_info('All configuration files generated successfully.')
+}
+
+
+/////////////NORMALLY NO NEED TO TOUCH
+
+pub fn heroscript_loads(heroscript string) !NextcloudK8SInstaller {
+	mut obj := encoderhero.decode[NextcloudK8SInstaller](heroscript)!
+	return obj
+}

--- a/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_model.v
+++ b/lib/k8_apps/biz/k8_nextcloud/k8_nextcloud_model.v
@@ -14,19 +14,25 @@ const default = false
 
 struct ConfigValues {
 pub mut:
-	hostname                string
-	backends                string
-	namespace               string
-	nextcloud_storage_size  string
-	postgres_storage_size   string
-	admin_user              string
-	admin_password          string
-	db_name                 string
-	db_user                 string
-	db_password             string
-	postgres_host           string
-	redis_host              string
-	fqdn                    string
+	hostname                  string
+	backends                  string
+	namespace                 string
+	nextcloud_storage_size    string
+	postgres_storage_size     string
+	admin_user                string
+	admin_password            string
+	db_name                   string
+	db_user                   string
+	db_password               string
+	postgres_host             string
+	redis_host                string
+	fqdn                      string
+	onlyoffice_enabled        bool
+	onlyoffice_jwt_secret     string
+	onlyoffice_host           string
+	onlyoffice_hostname       string  // OnlyOffice TFGW hostname
+	onlyoffice_fqdn           string  // OnlyOffice public FQDN for browser access
+	onlyoffice_middleware_ref string  // Full Traefik middleware reference
 }
 
 @[heap]
@@ -53,12 +59,17 @@ pub mut:
 	// Redis (no auth by default)
 	redis_host string = 'nextcloud-redis'
 	
+	// OnlyOffice integration
+	onlyoffice_enabled    bool   = true
+	onlyoffice_jwt_secret string // Auto-generated if empty
+	
 	// YAML output paths
-	secrets_path   string = '/tmp/nextcloud/secrets.yaml'
-	postgres_path  string = '/tmp/nextcloud/postgres.yaml'
-	redis_path     string = '/tmp/nextcloud/redis.yaml'
-	tfgw_path      string = '/tmp/nextcloud/tfgw.yaml'
-	nextcloud_path string = '/tmp/nextcloud/nextcloud.yaml'
+	secrets_path    string = '/tmp/nextcloud/secrets.yaml'
+	postgres_path   string = '/tmp/nextcloud/postgres.yaml'
+	redis_path      string = '/tmp/nextcloud/redis.yaml'
+	tfgw_path       string = '/tmp/nextcloud/tfgw.yaml'
+	nextcloud_path  string = '/tmp/nextcloud/nextcloud.yaml'
+	onlyoffice_path string = '/tmp/nextcloud/onlyoffice.yaml'
 	
 	// Internal
 	kube_client kubernetes.KubeClient @[skip]
@@ -100,6 +111,11 @@ fn obj_init(mycfg_ NextcloudK8SInstaller) !NextcloudK8SInstaller {
 	if mycfg.db_password == '' {
 		mycfg.db_password = generate_password()
 		console.print_info('Generated database password: ${mycfg.db_password}')
+	}
+	
+	if mycfg.onlyoffice_enabled && mycfg.onlyoffice_jwt_secret == '' {
+		mycfg.onlyoffice_jwt_secret = generate_password()
+		console.print_info('Generated OnlyOffice JWT secret: ${mycfg.onlyoffice_jwt_secret}')
 	}
 	
 	mycfg.kube_client = kubernetes.get(create: true)!
@@ -148,28 +164,49 @@ fn configure_tfgw() ! {
 	console.print_info('TFGW configuration file generated.')
 }
 
-// Generate remaining YAML files using the actual FQDN from TFGW
-fn configure_with_fqdn(fqdn string) ! {
+// Generate remaining YAML files using the actual FQDNs from TFGW
+fn configure_with_fqdn(fqdn string, onlyoffice_fqdn string) ! {
 	mut installer := get()!
 	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
 	
 	console.print_info('Generating configuration files with FQDN: ${fqdn}...')
 	
-	// Create config_values for template generation with actual FQDN
+	// Get master IPs again for backends (needed for OnlyOffice TFGW)
+	master_ips := core.get_master_node_ips(mut k8s)!
+	mut backends_str_builder := strings.new_builder(100)
+	for ip in master_ips {
+		backends_str_builder.writeln('    - "http://[${ip}]:80"')
+	}
+	
+	// Generate OnlyOffice hostname from the FQDN
+	onlyoffice_hostname := if onlyoffice_fqdn.len > 0 {
+		onlyoffice_fqdn.all_before('.')
+	} else {
+		'${k8app.hostname}office'
+	}
+	
+	// Create config_values for template generation with actual FQDNs
 	mut config_values := ConfigValues{
-		hostname:               k8app.hostname
-		backends:               ''
-		namespace:              k8app.namespace
-		nextcloud_storage_size: installer.nextcloud_storage_size
-		postgres_storage_size:  installer.postgres_storage_size
-		admin_user:             installer.admin_user
-		admin_password:         installer.admin_password
-		db_name:                installer.db_name
-		db_user:                installer.db_user
-		db_password:            installer.db_password
-		postgres_host:          'nextcloud-postgres'
-		redis_host:             installer.redis_host
-		fqdn:                   fqdn
+		hostname:                  k8app.hostname
+		backends:                  backends_str_builder.str()
+		namespace:                 k8app.namespace
+		nextcloud_storage_size:    installer.nextcloud_storage_size
+		postgres_storage_size:     installer.postgres_storage_size
+		admin_user:                installer.admin_user
+		admin_password:            installer.admin_password
+		db_name:                   installer.db_name
+		db_user:                   installer.db_user
+		db_password:               installer.db_password
+		postgres_host:             'nextcloud-postgres'
+		redis_host:                installer.redis_host
+		fqdn:                      fqdn
+		onlyoffice_enabled:        installer.onlyoffice_enabled
+		onlyoffice_jwt_secret:     installer.onlyoffice_jwt_secret
+		onlyoffice_host:           'onlyoffice'
+		onlyoffice_hostname:       onlyoffice_hostname
+		onlyoffice_fqdn:           onlyoffice_fqdn
+		onlyoffice_middleware_ref: '${k8app.namespace}-onlyoffice-force-https@kubernetescrd'
 	}
 	
 	// Generate Secrets YAML
@@ -199,6 +236,14 @@ fn configure_with_fqdn(fqdn string) ! {
 	mut nextcloud_path := pathlib.get_file(path: installer.nextcloud_path, create: true)!
 	nextcloud_path.write(nextcloud_yaml)!
 	console.print_info('Nextcloud configuration file generated.')
+	
+	// Generate OnlyOffice YAML if enabled
+	if installer.onlyoffice_enabled {
+		onlyoffice_yaml := $tmpl('./templates/onlyoffice.yaml')
+		mut onlyoffice_path := pathlib.get_file(path: installer.onlyoffice_path, create: true)!
+		onlyoffice_path.write(onlyoffice_yaml)!
+		console.print_info('OnlyOffice configuration file generated.')
+	}
 	
 	console.print_info('All configuration files generated successfully.')
 }

--- a/lib/k8_apps/biz/k8_nextcloud/readme.md
+++ b/lib/k8_apps/biz/k8_nextcloud/readme.md
@@ -1,0 +1,44 @@
+# k8_nextcloud
+
+
+
+To get started
+
+```v
+
+
+import incubaid.herolib.installers.something.k8_nextcloud as k8_nextcloud_installer
+
+heroscript:="
+!!k8_nextcloud.configure name:'test'
+ password: '1234'
+ port: 7701
+
+!!k8_nextcloud.start name:'test' reset:1 
+"
+
+k8_nextcloud_installer.play(heroscript=heroscript)!
+
+//or we can call the default and do a start with reset
+//mut installer:= k8_nextcloud_installer.get()!
+//installer.start(reset:true)!
+
+
+
+
+```
+
+## example heroscript
+
+
+```hero
+!!k8_nextcloud.configure
+    homedir: '/home/user/k8_nextcloud'
+    username: 'admin'
+    password: 'secretpassword'
+    title: 'Some Title'
+    host: 'localhost'
+    port: 8888
+
+```
+

--- a/lib/k8_apps/biz/k8_nextcloud/templates/atemplate.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/atemplate.yaml
@@ -1,0 +1,5 @@
+
+
+name: ${cfg.configpath}
+
+

--- a/lib/k8_apps/biz/k8_nextcloud/templates/nextcloud.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/nextcloud.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nextcloud-data
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: nextcloud
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: @{config_values.nextcloud_storage_size}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nextcloud-php-overrides
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: nextcloud
+    app.kubernetes.io/part-of: nextcloud
+data:
+  zz-php.ini: |
+    memory_limit=512M
+    upload_max_filesize=2G
+    post_max_size=2G
+    opcache.enable=1
+    opcache.enable_cli=1
+    opcache.interned_strings_buffer=16
+    opcache.max_accelerated_files=10000
+    opcache.memory_consumption=128
+    opcache.save_comments=1
+    opcache.revalidate_freq=1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextcloud-web
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: nextcloud
+    app.kubernetes.io/part-of: nextcloud
+    app.kubernetes.io/component: web
+spec:
+  selector:
+    app.kubernetes.io/name: nextcloud
+    app.kubernetes.io/part-of: nextcloud
+    app.kubernetes.io/component: web
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nextcloud
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: nextcloud
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nextcloud
+      app.kubernetes.io/part-of: nextcloud
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nextcloud
+        app.kubernetes.io/part-of: nextcloud
+        app.kubernetes.io/component: web
+    spec:
+      securityContext:
+        fsGroup: 33
+        fsGroupChangePolicy: Always
+      containers:
+      - name: nextcloud
+        image: nextcloud:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+        - name: NEXTCLOUD_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-admin
+              key: NEXTCLOUD_ADMIN_USER
+        - name: NEXTCLOUD_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-admin
+              key: NEXTCLOUD_ADMIN_PASSWORD
+        - name: POSTGRES_HOST
+          value: @{config_values.postgres_host}
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-db
+              key: POSTGRES_DB
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-db
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-db
+              key: POSTGRES_PASSWORD
+        - name: REDIS_HOST
+          value: @{config_values.redis_host}
+        - name: NEXTCLOUD_TRUSTED_DOMAINS
+          value: @{config_values.fqdn}
+        - name: OVERWRITEHOST
+          value: @{config_values.fqdn}
+        - name: OVERWRITEPROTOCOL
+          value: https
+        - name: OVERWRITECLIURL
+          value: https://@{config_values.fqdn}
+        readinessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 12
+        livenessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 3
+          failureThreshold: 10
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "512Mi"
+          limits:
+            cpu: "2000m"
+            memory: "2Gi"
+        volumeMounts:
+        - name: nextcloud-data
+          mountPath: /var/www/html
+        - name: php-overrides
+          mountPath: /usr/local/etc/php/conf.d/zz-php.ini
+          subPath: zz-php.ini
+      volumes:
+      - name: nextcloud-data
+        persistentVolumeClaim:
+          claimName: nextcloud-data
+      - name: php-overrides
+        configMap:
+          name: nextcloud-php-overrides
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nextcloud
+  namespace: @{config_values.namespace}
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: @{config_values.fqdn}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nextcloud-web
+            port:
+              number: 80

--- a/lib/k8_apps/biz/k8_nextcloud/templates/nextcloud.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/nextcloud.yaml
@@ -115,7 +115,7 @@ spec:
         - name: REDIS_HOST
           value: @{config_values.redis_host}
         - name: NEXTCLOUD_TRUSTED_DOMAINS
-          value: @{config_values.fqdn}
+          value: "@{config_values.fqdn} nextcloud-web nextcloud-web.@{config_values.namespace}.svc.cluster.local"
         - name: OVERWRITEHOST
           value: @{config_values.fqdn}
         - name: OVERWRITEPROTOCOL

--- a/lib/k8_apps/biz/k8_nextcloud/templates/onlyoffice.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/onlyoffice.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onlyoffice-jwt
+  namespace: @{config_values.namespace}
+type: Opaque
+stringData:
+  JWT_SECRET: "@{config_values.onlyoffice_jwt_secret}"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: onlyoffice
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: onlyoffice
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  selector:
+    app.kubernetes.io/name: onlyoffice
+    app.kubernetes.io/part-of: nextcloud
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onlyoffice
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: onlyoffice
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: onlyoffice
+      app.kubernetes.io/part-of: nextcloud
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: onlyoffice
+        app.kubernetes.io/part-of: nextcloud
+    spec:
+      containers:
+      - name: onlyoffice
+        image: onlyoffice/documentserver:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+        - name: JWT_ENABLED
+          value: "true"
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: onlyoffice-jwt
+              key: JWT_SECRET
+        - name: JWT_HEADER
+          value: "Authorization"
+        - name: JWT_IN_BODY
+          value: "true"
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "512Mi"
+          limits:
+            cpu: "2000m"
+            memory: "4Gi"
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 10
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 3
+          failureThreshold: 5
+---
+apiVersion: ingress.grid.tf/v1
+kind: TFGW
+metadata:
+  name: onlyoffice
+  namespace: @{config_values.namespace}
+spec:
+  hostname: "@{config_values.onlyoffice_hostname}"
+  backends:
+@{config_values.backends}
+---
+# Traefik Middleware to force HTTPS headers for OnlyOffice
+# This fixes Mixed Content errors when browser tries to load OnlyOffice assets
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: onlyoffice-force-https
+  namespace: @{config_values.namespace}
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Proto: "https"
+      X-Forwarded-Port: "443"
+      X-Forwarded-Ssl: "on"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: onlyoffice
+  namespace: @{config_values.namespace}
+  annotations:
+    # Apply middleware to force HTTPS headers for OnlyOffice
+    traefik.ingress.kubernetes.io/router.middlewares: "@{config_values.onlyoffice_middleware_ref}"
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: @{config_values.onlyoffice_fqdn}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: onlyoffice
+            port:
+              number: 80

--- a/lib/k8_apps/biz/k8_nextcloud/templates/postgres.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/postgres.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: @{config_values.postgres_host}
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: nextcloud
+  ports:
+  - name: pg
+    port: 5432
+    targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: @{config_values.postgres_host}
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  serviceName: @{config_values.postgres_host}
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/part-of: nextcloud
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/part-of: nextcloud
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+      - name: postgres
+        image: postgres:16
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5432
+          name: pg
+        env:
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-db
+              key: POSTGRES_DB
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-db
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: nextcloud-db
+              key: POSTGRES_PASSWORD
+        volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1Gi"
+      terminationGracePeriodSeconds: 30
+  volumeClaimTemplates:
+  - metadata:
+      name: pgdata
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/part-of: nextcloud
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: @{config_values.postgres_storage_size}

--- a/lib/k8_apps/biz/k8_nextcloud/templates/redis.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/redis.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: @{config_values.redis_host}
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: nextcloud
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: @{config_values.redis_host}
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/part-of: nextcloud
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/part-of: nextcloud
+    spec:
+      containers:
+      - name: redis
+        image: redis:7-alpine
+        imagePullPolicy: IfNotPresent
+        args: ["--save", "", "--appendonly", "no"]
+        ports:
+        - containerPort: 6379
+          name: redis
+        resources:
+          requests:
+            cpu: "20m"
+            memory: "64Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"

--- a/lib/k8_apps/biz/k8_nextcloud/templates/secrets.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nextcloud-db
+  namespace: @{config_values.namespace}
+type: Opaque
+stringData:
+  POSTGRES_DB: "@{config_values.db_name}"
+  POSTGRES_USER: "@{config_values.db_user}"
+  POSTGRES_PASSWORD: "@{config_values.db_password}"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nextcloud-admin
+  namespace: @{config_values.namespace}
+type: Opaque
+stringData:
+  NEXTCLOUD_ADMIN_USER: "@{config_values.admin_user}"
+  NEXTCLOUD_ADMIN_PASSWORD: "@{config_values.admin_password}"

--- a/lib/k8_apps/biz/k8_nextcloud/templates/tfgw.yaml
+++ b/lib/k8_apps/biz/k8_nextcloud/templates/tfgw.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: @{config_values.namespace}
+---
+apiVersion: ingress.grid.tf/v1
+kind: TFGW
+metadata:
+  name: nextcloud
+  namespace: @{config_values.namespace}
+spec:
+  hostname: "@{config_values.hostname}"
+  backends:
+@{config_values.backends}

--- a/lib/k8_apps/communication/k8_element_chat/element_chat_factory_.v
+++ b/lib/k8_apps/communication/k8_element_chat/element_chat_factory_.v
@@ -15,7 +15,7 @@ __global (
 @[params]
 pub struct ArgsGet {
 pub mut:
-	name   string = 'element_chat'
+	name   string = element_chat_default
 	fromdb bool // will load from filesystem
 	create bool // default will not create if not exist
 }

--- a/lib/k8_apps/communication/k8_element_chat/element_chat_model.v
+++ b/lib/k8_apps/communication/k8_element_chat/element_chat_model.v
@@ -2,8 +2,8 @@ module k8_element_chat
 
 import incubaid.herolib.ui.console
 import incubaid.herolib.data.encoderhero
-import incubaid.herolib.virt.kubernetes
 import incubaid.herolib.core.pathlib
+import incubaid.herolib.k8_apps.core
 import strings
 
 pub const version = '0.0.0'
@@ -48,7 +48,8 @@ pub mut:
 	tfgw_path        string = '/tmp/element_chat/tfgw-element.yaml'
 	conduit_cfg_path string = '/tmp/element_chat/conduit.toml'
 	element_cfg_path string = '/tmp/element_chat/element-config.json'
-	kube_client      kubernetes.KubeClient @[skip]
+	// K8App instance for kubernetes operations
+	k8app ?core.K8App @[skip]
 }
 
 // your checking & initialization code if needed
@@ -59,18 +60,19 @@ fn obj_init(mycfg_ ElementChat) !ElementChat {
 		mycfg.name = 'elementchat'
 	}
 
-	// Replace the dashes, dots, and underscores with nothing
-	mycfg.name = mycfg.name.replace('_', '')
-	mycfg.name = mycfg.name.replace('-', '')
-	mycfg.name = mycfg.name.replace('.', '')
+	// Use core name_fix for consistent name handling
+	mycfg.name = core.name_fix(mycfg.name)
 
 	if mycfg.namespace == '' {
-		mycfg.namespace = '${mycfg.name}-element-chat-namespace'
+		mycfg.namespace = '${mycfg.name}elementchatns'
 	}
 
-	if mycfg.namespace.contains('_') || mycfg.namespace.contains('.') {
-		console.print_stderr('namespace cannot contain _, was: ${mycfg.namespace}, use dashes instead.')
-		return error('namespace cannot contain _, was: ${mycfg.namespace}')
+	// Apply name_fix to namespace for consistency with k8app
+	mycfg.namespace = core.name_fix(mycfg.namespace)
+
+	if mycfg.namespace.contains('.') {
+		console.print_stderr('namespace cannot contain ., was: ${mycfg.namespace}')
+		return error('namespace cannot contain ., was: ${mycfg.namespace}')
 	}
 
 	if mycfg.matrix_hostname == '' {
@@ -81,8 +83,16 @@ fn obj_init(mycfg_ ElementChat) !ElementChat {
 		mycfg.element_hostname = '${mycfg.name}element'
 	}
 
-	mycfg.kube_client = kubernetes.get(create: true)!
-	mycfg.kube_client.config.namespace = mycfg.namespace
+	// Validate hostnames don't exceed TFGW limit
+	mycfg.matrix_hostname = core.validate_hostname(mycfg.matrix_hostname)
+	mycfg.element_hostname = core.validate_hostname(mycfg.element_hostname)
+
+	// Initialize K8App for kubernetes operations
+	mycfg.k8app = core.k8app(
+		app_name: 'elementchat'
+		app_instance: mycfg.name
+		namespace: mycfg.namespace
+	)!
 	return mycfg
 }
 
@@ -90,7 +100,11 @@ fn obj_init(mycfg_ ElementChat) !ElementChat {
 fn configure() ! {
 	mut installer := get()!
 
-	master_ips := get_master_node_ips()!
+	// Unwrap k8app once
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+
+	master_ips := core.get_master_node_ips(mut k8s)!
 	console.print_info('Master node IPs: ${master_ips}')
 
 	mut backends_str_builder := strings.new_builder(100)
@@ -101,11 +115,12 @@ fn configure() ! {
 	console.print_info('Generating configuration files from templates...')
 
 	// Create config_values for template generation
+	// Use k8app.namespace to ensure consistency with kubernetes client
 	mut config_values := ConfigValues{
 		matrix_hostname:    installer.matrix_hostname
 		element_hostname:   installer.element_hostname
 		backends:           backends_str_builder.str()
-		namespace:          installer.namespace
+		namespace:          k8app.namespace
 		conduit_port:       installer.conduit_port
 		database_backend:   installer.database_backend
 		database_path:      installer.database_path
@@ -160,27 +175,6 @@ fn configure() ! {
 	chat_app_path.write(chat_app_yaml)!
 
 	console.print_info('Configuration files generated successfully.')
-}
-
-// Get Kubernetes master node IPs
-fn get_master_node_ips() ![]string {
-	mut master_ips := []string{}
-	installer := get()!
-
-	// Get all nodes using the kubernetes client
-	mut k8s := installer.kube_client
-	nodes := k8s.get_nodes()!
-
-	// Extract IPv6 internal IPs from all nodes (dual-stack support)
-	for node in nodes {
-		// Check all internal IPs (not just the first one) for IPv6 addresses
-		for ip in node.internal_ips {
-			if ip.len > 0 && ip.contains(':') {
-				master_ips << ip
-			}
-		}
-	}
-	return master_ips
 }
 
 /////////////NORMALLY NO NEED TO TOUCH

--- a/lib/k8_apps/communication/stalwart/.heroscript
+++ b/lib/k8_apps/communication/stalwart/.heroscript
@@ -1,0 +1,12 @@
+
+!!hero_code.generate_installer
+    name:''
+    classname:'Stalwart'
+    singleton:0
+    templates:1
+    default:1
+    title:''
+    supported_platforms:''
+    startupmanager:0
+	hasconfig:1
+    build:0

--- a/lib/k8_apps/communication/stalwart/readme.md
+++ b/lib/k8_apps/communication/stalwart/readme.md
@@ -1,0 +1,72 @@
+# Stalwart Mail Server K8s Installer
+
+Deploy **Stalwart Mail** (SMTP/IMAP/POP3/Sieve) + **JMAP/CalDAV/CardDAV/UI** on a k3s cluster.
+
+## Architecture
+
+```
+(Internet) ── HTTPS ──▶ TFGW ── HTTP ──▶ Traefik Ingress ──▶ Service (stalwart-http:80) ─▶ Pod (JMAP/DAV/UI :8080)
+
+Mail clients ── Mycelium IPv6 TCP ──▶ ServiceLB (stalwart-mail: 25/465/587/143/993/110/995/4190 DNAT) ─▶ Pod (Stalwart)
+```
+
+## Features
+
+- **TFGW** generates an HTTPS FQDN (`https://<hostname>.gent01.grid.tf`) for web access
+- **Traefik Ingress** for all web protocols (JMAP/DAV/UI on :8080 inside the pod)
+- **k3s ServiceLB (klipper-lb)** as a **dual-stack** LoadBalancer for mail TCP ports
+- **ConfigMap** with embedded `config.toml` and **PVC** for Stalwart data/logs
+
+## Usage
+
+```v
+import incubaid.herolib.k8_apps.communication.stalwart
+
+// Create installer instance
+mut installer := stalwart.get(
+    name:   'mymail'
+    create: true
+)!
+
+// Optional: customize settings
+installer.hostname = 'mymail'           // TFGW hostname
+installer.admin_user = 'admin'          // Admin username
+installer.admin_password = 'secure123'  // Admin password
+installer.storage_size = '50Gi'         // PVC storage size
+installer.log_level = 'info'            // Log level
+
+// Install
+installer.install()!
+
+// Destroy when done
+// installer.destroy()!
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `name` | `stalwart` | Instance name |
+| `hostname` | `{name}mail` | TFGW hostname |
+| `namespace` | `{name}stalwartns` | Kubernetes namespace |
+| `admin_user` | `admin` | Admin username |
+| `admin_password` | `changeme123` | Admin password |
+| `storage_size` | `20Gi` | PVC storage size |
+| `http_port` | `8080` | HTTP port for web UI |
+| `log_level` | `info` | Log level (info, debug, warn, error) |
+
+## Mail Ports
+
+The LoadBalancer service exposes these ports:
+
+| Port | Protocol | Description |
+|------|----------|-------------|
+| 25 | SMTP | Mail submission |
+| 465 | SMTPS | SMTP over TLS |
+| 587 | Submission | Mail submission (STARTTLS) |
+| 143 | IMAP | IMAP access |
+| 993 | IMAPS | IMAP over TLS |
+| 110 | POP3 | POP3 access |
+| 995 | POP3S | POP3 over TLS |
+| 4190 | ManageSieve | Sieve filter management |
+

--- a/lib/k8_apps/communication/stalwart/stalwart_actions.v
+++ b/lib/k8_apps/communication/stalwart/stalwart_actions.v
@@ -1,4 +1,4 @@
-module k8_element_chat
+module stalwart
 
 import incubaid.herolib.ui.console
 import incubaid.herolib.installers.ulist
@@ -13,25 +13,20 @@ pub fn installed() !bool {
 	k8app := installer.k8app or { return error('k8app not initialized') }
 	mut k8s := k8app.kube_client
 
-	// Try to get the conduit deployment
+	// Try to get the stalwart deployment
 	deployments := k8s.get_deployments(k8app.namespace) or {
 		// If we can't get deployments, it's not running
 		return false
 	}
 
-	// Check if conduit and element-web deployments exist
-	mut conduit_found := false
-	mut element_found := false
+	// Check if stalwart deployment exists
 	for deployment in deployments {
-		if deployment.name == 'conduit' {
-			conduit_found = true
-		}
-		if deployment.name == 'element-web' {
-			element_found = true
+		if deployment.name == 'stalwart' {
+			return true
 		}
 	}
 
-	return conduit_found && element_found
+	return false
 }
 
 // get the Upload List of the files
@@ -43,13 +38,13 @@ fn ulist_get() !ulist.UList {
 // uploads to S3 server if configured
 fn upload() ! {
 	// installers.upload(
-	//     cmdname: 'element_chat'
-	//     source: '${gitpath}/target/x86_64-unknown-linux-musl/release/element_chat'
+	//     cmdname: 'stalwart'
+	//     source: '${gitpath}/target/x86_64-unknown-linux-musl/release/stalwart'
 	// )!
 }
 
 fn install() ! {
-	console.print_header('Installing Element Chat...')
+	console.print_header('Installing Stalwart Mail Server...')
 
 	// Get installer config to access namespace
 	installer := get()!
@@ -62,27 +57,26 @@ fn install() ! {
 	core.kubectl_installed(mut k8s)!
 	console.print_info('kubectl is installed and configured.')
 
-	// 4. Apply the YAML files using kubernetes client
+	// 2. Apply the YAML files using kubernetes client
 	console.print_info('Applying Gateway YAML file to the cluster...')
-	res1 := k8s.apply_yaml('/tmp/element_chat/tfgw-element.yaml')!
+	res1 := k8s.apply_yaml(installer.tfgw_path)!
 	if !res1.success {
-		return error('Failed to apply tfgw-element.yaml: ${res1.stderr}')
+		return error('Failed to apply tfgw-stalwart.yaml: ${res1.stderr}')
 	}
 	console.print_info('Gateway YAML file applied successfully.')
 
-	// 5. Verify TFGW deployments
-	core.verify_tfgw_deployment(tfgw_name: 'matrix-gw', namespace: k8app.namespace, k8s: k8s)!
-	core.verify_tfgw_deployment(tfgw_name: 'element-gw', namespace: k8app.namespace, k8s: k8s)!
+	// 3. Verify TFGW deployment
+	core.verify_tfgw_deployment(tfgw_name: 'stalwart-tfgw', namespace: k8app.namespace, k8s: k8s)!
 
-	// 6. Apply Chat App YAML
-	console.print_info('Applying Chat App YAML file to the cluster...')
-	res2 := k8s.apply_yaml('/tmp/element_chat/chat-app.yaml')!
+	// 4. Apply Stalwart App YAML
+	console.print_info('Applying Stalwart App YAML file to the cluster...')
+	res2 := k8s.apply_yaml(installer.stalwart_app_path)!
 	if !res2.success {
-		return error('Failed to apply chat-app.yaml: ${res2.stderr}')
+		return error('Failed to apply stalwart-app.yaml: ${res2.stderr}')
 	}
-	console.print_info('Chat App YAML file applied successfully.')
+	console.print_info('Stalwart App YAML file applied successfully.')
 
-	// 7. Verify deployment status
+	// 5. Verify deployment status
 	console.print_info('Verifying deployment status...')
 	mut is_running := false
 	for i in 0 .. core.max_deployment_retries {
@@ -90,16 +84,17 @@ fn install() ! {
 			is_running = true
 			break
 		}
-		console.print_info('Waiting for Element Chat deployment to be ready... (${i + 1}/${core.max_deployment_retries})')
+		console.print_info('Waiting for Stalwart deployment to be ready... (${i + 1}/${core.max_deployment_retries})')
 		time.sleep(core.deployment_check_interval_seconds * time.second)
 	}
 
 	if is_running {
-		console.print_header('Element Chat installation successful!')
-		console.print_header('You can access Element Chat at https://${installer.element_hostname}.gent01.grid.tf')
-		console.print_header('You can access Matrix at https://${installer.matrix_hostname}.gent01.grid.tf')
+		console.print_header('Stalwart Mail Server installation successful!')
+		console.print_header('You can access Stalwart Web UI at https://${installer.hostname}.gent01.grid.tf')
+		console.print_header('Admin user: ${installer.admin_user}')
+		console.print_info('Mail ports (SMTP/IMAP/POP3) are available via LoadBalancer service.')
 	} else {
-		return error('Element Chat deployment failed to start.')
+		return error('Stalwart deployment failed to start.')
 	}
 }
 
@@ -107,6 +102,6 @@ fn destroy() ! {
 	installer := get()!
 	k8app := installer.k8app or { return error('k8app not initialized') }
 	mut k8s := k8app.kube_client
-	
+
 	core.destroy_namespace(mut k8s, k8app.namespace)!
 }

--- a/lib/k8_apps/communication/stalwart/stalwart_factory_.v
+++ b/lib/k8_apps/communication/stalwart/stalwart_factory_.v
@@ -1,4 +1,4 @@
-module k8_gitea
+module stalwart
 
 import incubaid.herolib.core.base
 import incubaid.herolib.core.playbook { PlayBook }
@@ -6,8 +6,8 @@ import incubaid.herolib.ui.console
 import json
 
 __global (
-	k8_gitea_global  map[string]&GiteaK8SInstaller
-	k8_gitea_default string
+	stalwart_global  map[string]&Stalwart
+	stalwart_default string
 )
 
 /////////FACTORY
@@ -15,72 +15,68 @@ __global (
 @[params]
 pub struct ArgsGet {
 pub mut:
-	name   string = k8_gitea_default
+	name   string = stalwart_default
 	fromdb bool // will load from filesystem
 	create bool // default will not create if not exist
 }
 
-pub fn new(args ArgsGet) !&GiteaK8SInstaller {
-	mut obj := GiteaK8SInstaller{
+pub fn new(args ArgsGet) !&Stalwart {
+	mut obj := Stalwart{
 		name: args.name
 	}
 	set(obj)!
 	return get(name: args.name)!
 }
 
-pub fn get(args_ ArgsGet) !&GiteaK8SInstaller {
+pub fn get(args ArgsGet) !&Stalwart {
 	mut context := base.context()!
-	mut args := args_
-	if args.name == 'gitea' && k8_gitea_default != '' {
-		args.name = k8_gitea_default
-	}
-
-	if args.fromdb || args.name !in k8_gitea_global {
+	stalwart_default = args.name
+	if args.fromdb || args.name !in stalwart_global {
 		mut r := context.redis()!
-		if r.hexists('context:k8_gitea', args.name)! {
-			data := r.hget('context:k8_gitea', args.name)!
+		if r.hexists('context:stalwart', args.name)! {
+			data := r.hget('context:stalwart', args.name)!
 			if data.len == 0 {
 				print_backtrace()
-				return error('GiteaK8SInstaller with name: ${args.name} does not exist, prob bug.')
+				return error('Stalwart with name: ${args.name} does not exist, prob bug.')
 			}
-			mut obj := json.decode(GiteaK8SInstaller, data)!
+			mut obj := json.decode(Stalwart, data)!
 			set_in_mem(obj)!
 		} else {
 			if args.create {
 				new(args)!
 			} else {
 				print_backtrace()
-				return error("GiteaK8SInstaller with name '${args.name}' does not exist")
+				return error("Stalwart with name '${args.name}' does not exist")
 			}
 		}
 		return get(name: args.name)! // no longer from db nor create
 	}
-	return k8_gitea_global[args.name] or {
+	return stalwart_global[args.name] or {
 		print_backtrace()
-		return error('could not get config for k8_gitea with name:${args.name}')
+		return error('could not get config for stalwart with name:${args.name}')
 	}
 }
 
 // register the config for the future
-pub fn set(o GiteaK8SInstaller) ! {
+pub fn set(o Stalwart) ! {
 	mut o2 := set_in_mem(o)!
-	k8_gitea_default = o2.name
+	stalwart_default = o2.name
 	mut context := base.context()!
 	mut r := context.redis()!
-	r.hset('context:k8_gitea', o2.name, json.encode(o2))!
+	r.hset('context:stalwart', o2.name, json.encode(o2))!
 }
 
 // does the config exists?
 pub fn exists(args ArgsGet) !bool {
 	mut context := base.context()!
 	mut r := context.redis()!
-	return r.hexists('context:k8_gitea', args.name)!
+	return r.hexists('context:stalwart', args.name)!
 }
 
 pub fn delete(args ArgsGet) ! {
 	mut context := base.context()!
 	mut r := context.redis()!
-	r.hdel('context:k8_gitea', args.name)!
+	r.hdel('context:stalwart', args.name)!
 }
 
 @[params]
@@ -90,17 +86,17 @@ pub mut:
 }
 
 // if fromdb set: load from filesystem, and not from mem, will also reset what is in mem
-pub fn list(args ArgsList) ![]&GiteaK8SInstaller {
-	mut res := []&GiteaK8SInstaller{}
+pub fn list(args ArgsList) ![]&Stalwart {
+	mut res := []&Stalwart{}
 	mut context := base.context()!
 	if args.fromdb {
 		// reset what is in mem
-		k8_gitea_global = map[string]&GiteaK8SInstaller{}
-		k8_gitea_default = ''
+		stalwart_global = map[string]&Stalwart{}
+		stalwart_default = ''
 	}
 	if args.fromdb {
 		mut r := context.redis()!
-		mut l := r.hkeys('context:k8_gitea')!
+		mut l := r.hkeys('context:stalwart')!
 
 		for name in l {
 			res << get(name: name, fromdb: true)!
@@ -108,7 +104,7 @@ pub fn list(args ArgsList) ![]&GiteaK8SInstaller {
 		return res
 	} else {
 		// load from memory
-		for _, client in k8_gitea_global {
+		for _, client in stalwart_global {
 			res << client
 		}
 	}
@@ -116,18 +112,18 @@ pub fn list(args ArgsList) ![]&GiteaK8SInstaller {
 }
 
 // only sets in mem, does not set as config
-fn set_in_mem(o GiteaK8SInstaller) !GiteaK8SInstaller {
+fn set_in_mem(o Stalwart) !Stalwart {
 	mut o2 := obj_init(o)!
-	k8_gitea_global[o2.name] = &o2
-	k8_gitea_default = o2.name
+	stalwart_global[o2.name] = &o2
+	stalwart_default = o2.name
 	return o2
 }
 
 pub fn play(mut plbook PlayBook) ! {
-	if !plbook.exists(filter: 'k8_gitea.') {
+	if !plbook.exists(filter: 'stalwart.') {
 		return
 	}
-	mut install_actions := plbook.find(filter: 'k8_gitea.configure')!
+	mut install_actions := plbook.find(filter: 'stalwart.configure')!
 	if install_actions.len > 0 {
 		for mut install_action in install_actions {
 			heroscript := install_action.heroscript()
@@ -136,17 +132,17 @@ pub fn play(mut plbook PlayBook) ! {
 			install_action.done = true
 		}
 	}
-	mut other_actions := plbook.find(filter: 'k8_gitea.')!
+	mut other_actions := plbook.find(filter: 'stalwart.')!
 	for mut other_action in other_actions {
 		if other_action.name in ['destroy', 'install', 'build'] {
 			mut p := other_action.params
 			reset := p.get_default_false('reset')
 			if other_action.name == 'destroy' || reset {
-				console.print_debug('install action k8_gitea.destroy')
+				console.print_debug('install action stalwart.destroy')
 				destroy()!
 			}
 			if other_action.name == 'install' {
-				console.print_debug('install action k8_gitea.install')
+				console.print_debug('install action stalwart.install')
 				install()!
 			}
 		}
@@ -159,9 +155,10 @@ pub fn play(mut plbook PlayBook) ! {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // load from disk and make sure is properly intialized
-pub fn (mut self GiteaK8SInstaller) reload() ! {
+pub fn (mut self Stalwart) reload() ! {
 	switch(self.name)
 	self = obj_init(self)!
+	set(self)!
 }
 
 @[params]
@@ -170,19 +167,19 @@ pub mut:
 	reset bool
 }
 
-pub fn (mut self GiteaK8SInstaller) install(args InstallArgs) ! {
+pub fn (mut self Stalwart) install(args InstallArgs) ! {
 	switch(self.name)
 	if args.reset || (!installed()!) {
 		install()!
 	}
 }
 
-pub fn (mut self GiteaK8SInstaller) destroy() ! {
+pub fn (mut self Stalwart) destroy() ! {
 	switch(self.name)
 	destroy()!
 }
 
-// switch instance to be used for k8_gitea
+// switch instance to be used for stalwart
 pub fn switch(name string) {
-	k8_gitea_default = name
+	stalwart_default = name
 }

--- a/lib/k8_apps/communication/stalwart/stalwart_model.v
+++ b/lib/k8_apps/communication/stalwart/stalwart_model.v
@@ -1,0 +1,161 @@
+module stalwart
+
+import incubaid.herolib.ui.console
+import incubaid.herolib.data.encoderhero
+import incubaid.herolib.core.pathlib
+import incubaid.herolib.k8_apps.core
+import strings
+
+pub const version = '0.0.0'
+const singleton = false
+const default = false
+
+struct ConfigValues {
+pub mut:
+	hostname       string // The Stalwart hostname for TFGW
+	backends       string // The backends for the TFGW
+	namespace      string // The namespace for the Stalwart deployment
+	http_port      int    // HTTP port for web UI/JMAP/DAV
+	data_path      string // Data path inside container
+	log_level      string // Log level (info, debug, warn, error)
+	admin_user     string // Admin username
+	admin_password string // Admin password
+	storage_size   string // PVC storage size
+	config_toml    string // Generated config.toml content
+}
+
+@[heap]
+pub struct Stalwart {
+pub mut:
+	name      string = 'stalwart'
+	hostname  string
+	namespace string
+	// Stalwart configuration
+	http_port      int    = 8080
+	data_path      string = '/opt/stalwart'
+	log_level      string = 'info'
+	admin_user     string = 'admin'
+	admin_password string = 'changeme123' @[secret]
+	storage_size   string = '20Gi'
+	// Internal paths
+	stalwart_app_path string = '/tmp/stalwart/stalwart-app.yaml'
+	tfgw_path         string = '/tmp/stalwart/tfgw-stalwart.yaml'
+	// K8App instance for kubernetes operations
+	k8app ?core.K8App @[skip]
+}
+
+// your checking & initialization code if needed
+fn obj_init(mycfg_ Stalwart) !Stalwart {
+	mut mycfg := mycfg_
+
+	if mycfg.name == '' {
+		mycfg.name = 'stalwart'
+	}
+
+	// Use core name_fix for consistent name handling
+	mycfg.name = core.name_fix(mycfg.name)
+
+	if mycfg.namespace == '' {
+		mycfg.namespace = '${mycfg.name}stalwartns'
+	}
+
+	// Apply name_fix to namespace for consistency with k8app
+	mycfg.namespace = core.name_fix(mycfg.namespace)
+
+	if mycfg.namespace.contains('.') {
+		console.print_stderr('namespace cannot contain ., was: ${mycfg.namespace}')
+		return error('namespace cannot contain ., was: ${mycfg.namespace}')
+	}
+
+	if mycfg.hostname == '' {
+		mycfg.hostname = '${mycfg.name}mail'
+	}
+
+	// Validate hostname doesn't exceed TFGW limit
+	mycfg.hostname = core.validate_hostname(mycfg.hostname)
+
+	// Initialize K8App for kubernetes operations
+	mycfg.k8app = core.k8app(
+		app_name: 'stalwart'
+		app_instance: mycfg.name
+		namespace: mycfg.namespace
+	)!
+	return mycfg
+}
+
+// called before start if done
+fn configure() ! {
+	mut installer := get()!
+
+	// Unwrap k8app once
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
+
+	master_ips := core.get_master_node_ips(mut k8s)!
+	console.print_info('Master node IPs: ${master_ips}')
+
+	mut backends_str_builder := strings.new_builder(100)
+	for ip in master_ips {
+		backends_str_builder.writeln('    - "http://[${ip}]:80"')
+	}
+
+	console.print_info('Generating configuration files from templates...')
+
+	// Create config_values for template generation
+	// Use k8app.namespace to ensure consistency with kubernetes client
+	mut config_values := ConfigValues{
+		hostname:       installer.hostname
+		backends:       backends_str_builder.str()
+		namespace:      k8app.namespace
+		http_port:      installer.http_port
+		data_path:      installer.data_path
+		log_level:      installer.log_level
+		admin_user:     installer.admin_user
+		admin_password: installer.admin_password
+		storage_size:   installer.storage_size
+		config_toml:    ''
+	}
+
+	// Generate config.toml
+	config_toml_raw := $tmpl('./templates/config.toml.temp')
+
+	// Indent the config for proper YAML formatting (4 spaces for ConfigMap data)
+	config_toml_lines := config_toml_raw.split('\n')
+	mut config_toml_indented := strings.new_builder(config_toml_raw.len + 100)
+	for line in config_toml_lines {
+		if line.len > 0 {
+			config_toml_indented.writeln('    ${line}')
+		} else {
+			config_toml_indented.writeln('')
+		}
+	}
+
+	// Update config_values with the generated and indented config
+	config_values.config_toml = config_toml_indented.str()
+
+	// Ensure the output directory exists
+	_ := pathlib.get_dir(path: '/tmp/stalwart', create: true)!
+
+	// Generate TFGW YAML
+	tfgw_yaml := $tmpl('./templates/tfgw.yaml')
+	mut tfgw_path := pathlib.get_file(
+		path:   installer.tfgw_path
+		create: true
+		check:  true
+	)!
+	tfgw_path.write(tfgw_yaml)!
+
+	// Generate stalwart-app YAML
+	stalwart_app_yaml := $tmpl('./templates/stalwart-app.yaml')
+	mut stalwart_app_path := pathlib.get_file(path: installer.stalwart_app_path, create: true)!
+	stalwart_app_path.write(stalwart_app_yaml)!
+
+	console.print_info('Configuration files generated successfully.')
+}
+
+/////////////NORMALLY NO NEED TO TOUCH
+
+pub fn heroscript_loads(heroscript string) !Stalwart {
+	mut obj := encoderhero.decode[Stalwart](heroscript)!
+	return obj
+}

--- a/lib/k8_apps/communication/stalwart/templates/config.toml.temp
+++ b/lib/k8_apps/communication/stalwart/templates/config.toml.temp
@@ -1,0 +1,81 @@
+# ==========================
+# Stalwart server config
+# ==========================
+
+# ---- Mail listeners ----
+[server.listener.smtp]
+bind = "[::]:25"
+protocol = "smtp"
+
+[server.listener.submission]
+bind = "[::]:587"
+protocol = "smtp"
+
+[server.listener.submissions]
+bind = "[::]:465"
+protocol = "smtp"
+tls.implicit = true
+
+[server.listener.imap]
+bind = "[::]:143"
+protocol = "imap"
+
+[server.listener.imaptls]
+bind = "[::]:993"
+protocol = "imap"
+tls.implicit = true
+
+[server.listener.pop3]
+bind = "[::]:110"
+protocol = "pop3"
+
+[server.listener.pop3s]
+bind = "[::]:995"
+protocol = "pop3"
+tls.implicit = true
+
+[server.listener.sieve]
+bind = "[::]:4190"
+protocol = "managesieve"
+
+# ---- HTTP (UI/JMAP/DAV) routed via Ingress/TFGW ----
+[server.listener.http]
+protocol = "http"
+bind = "[::]:@{config_values.http_port}"
+
+# ---- Storage ----
+[storage]
+data = "rocksdb"
+fts = "rocksdb"
+blob = "rocksdb"
+lookup = "rocksdb"
+directory = "internal"
+
+[store.rocksdb]
+type = "rocksdb"
+path = "@{config_values.data_path}/data"
+compression = "lz4"
+
+[directory.internal]
+type = "internal"
+store = "rocksdb"
+
+# ---- Logging (file + stdout) ----
+[tracer.log]
+type = "log"
+level = "@{config_values.log_level}"
+path = "@{config_values.data_path}/logs"
+prefix = "stalwart.log"
+rotate = "daily"
+ansi = false
+enable = true
+
+[tracer.console]
+type = "stdout"
+level = "@{config_values.log_level}"
+enable = true
+
+# ---- Bootstrap admin ----
+[authentication.fallback-admin]
+user = "@{config_values.admin_user}"
+secret = "@{config_values.admin_password}"

--- a/lib/k8_apps/communication/stalwart/templates/stalwart-app.yaml
+++ b/lib/k8_apps/communication/stalwart/templates/stalwart-app.yaml
@@ -1,0 +1,149 @@
+# ---------- ConfigMap (embeds config.toml) ----------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stalwart-config
+  namespace: @{config_values.namespace}
+data:
+  config.toml: |
+@{config_values.config_toml}
+---
+# ---------- Persistent storage ----------
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stalwart-data
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: stalwart
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: @{config_values.storage_size}
+---
+# ---------- Deployment (no hostNetwork) ----------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stalwart
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: stalwart
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: stalwart
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: stalwart
+    spec:
+      containers:
+        - name: stalwart
+          image: stalwartlabs/stalwart:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+          volumeMounts:
+            - name: cfg
+              mountPath: /opt/stalwart/etc/config.toml
+              subPath: config.toml
+            - name: data
+              mountPath: /opt/stalwart
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: @{config_values.http_port}
+            initialDelaySeconds: 25
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            tcpSocket:
+              port: @{config_values.http_port}
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            requests: { cpu: 200m, memory: 512Mi }
+            limits:   { cpu: "2",  memory: 2Gi }
+      initContainers:
+        - name: init-dirs
+          image: busybox:1.36
+          command: ["sh","-lc","mkdir -p /opt/stalwart/data /opt/stalwart/logs && chmod -R 0777 /opt/stalwart"]
+          volumeMounts:
+            - name: data
+              mountPath: /opt/stalwart
+      volumes:
+        - name: cfg
+          configMap:
+            name: stalwart-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: stalwart-data
+---
+# ---------- ClusterIP for HTTP routed by Ingress ----------
+apiVersion: v1
+kind: Service
+metadata:
+  name: stalwart-http
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: stalwart
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: stalwart
+  ports:
+    - name: http
+      port: 80
+      targetPort: @{config_values.http_port}
+      protocol: TCP
+---
+# ---------- Ingress (host must match TFGW-minted FQDN) ----------
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stalwart-ingress
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: stalwart
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: @{config_values.hostname}.gent01.grid.tf
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: stalwart-http
+                port:
+                  number: 80
+---
+# ---------- Dual-stack LoadBalancer for mail TCP ports ----------
+apiVersion: v1
+kind: Service
+metadata:
+  name: stalwart-mail
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: stalwart
+spec:
+  type: LoadBalancer
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies: ["IPv4","IPv6"]
+  selector:
+    app.kubernetes.io/name: stalwart
+  ports:
+    - { name: smtp,   port: 25,   targetPort: 25,   protocol: TCP }
+    - { name: smtps,  port: 465,  targetPort: 465,  protocol: TCP }
+    - { name: msmtp,  port: 587,  targetPort: 587,  protocol: TCP }
+    - { name: imap,   port: 143,  targetPort: 143,  protocol: TCP }
+    - { name: imaps,  port: 993,  targetPort: 993,  protocol: TCP }
+    - { name: pop3,   port: 110,  targetPort: 110,  protocol: TCP }
+    - { name: pop3s,  port: 995,  targetPort: 995,  protocol: TCP }
+    - { name: sieve,  port: 4190, targetPort: 4190, protocol: TCP }

--- a/lib/k8_apps/communication/stalwart/templates/tfgw.yaml
+++ b/lib/k8_apps/communication/stalwart/templates/tfgw.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: @{config_values.namespace}
+---
+apiVersion: ingress.grid.tf/v1
+kind: TFGW
+metadata:
+  name: stalwart-tfgw
+  namespace: @{config_values.namespace}
+  labels:
+    app.kubernetes.io/name: tfgw
+    app.kubernetes.io/managed-by: kubecloud
+spec:
+  hostname: "@{config_values.hostname}"
+  backends:
+@{config_values.backends}

--- a/lib/k8_apps/core/k8app.v
+++ b/lib/k8_apps/core/k8app.v
@@ -88,6 +88,45 @@ pub fn get_master_node_ips(mut k8s kubernetes.KubeClient) ![]string {
 	return master_ips
 }
 
+// Parameters for getting TFGW FQDN
+@[params]
+pub struct GetTfgwFqdnArgs {
+pub mut:
+	tfgw_name string @[required]
+	namespace string @[required]
+	k8s       kubernetes.KubeClient @[required]
+	retry     int = max_deployment_retries
+}
+
+// Get the FQDN from TFGW status after it's generated
+// Returns the actual FQDN (e.g., "myapp.gent02.grid.tf")
+pub fn get_tfgw_fqdn(args GetTfgwFqdnArgs) !string {
+	console.print_info('Getting FQDN from TFGW ${args.tfgw_name}...')
+	mut k8s := args.k8s
+
+	for i in 0 .. args.retry {
+		result := k8s.kubectl_exec(
+			command: 'get tfgw ${args.tfgw_name} -n ${args.namespace} -o jsonpath="{.status.fqdn}"'
+		) or {
+			console.print_info('Waiting for FQDN to be generated for ${args.tfgw_name}... (${i + 1}/${args.retry})')
+			time.sleep(deployment_check_interval_seconds * time.second)
+			continue
+		}
+
+		if result.success && result.stdout != '' {
+			fqdn := result.stdout.trim('"').trim_space()
+			if fqdn.len > 0 {
+				console.print_info('TFGW FQDN: ${fqdn}')
+				return fqdn
+			}
+		}
+		console.print_info('Waiting for FQDN to be generated for ${args.tfgw_name}... (${i + 1}/${args.retry})')
+		time.sleep(deployment_check_interval_seconds * time.second)
+	}
+
+	return error('Failed to get FQDN for ${args.tfgw_name} after ${args.retry} retries.')
+}
+
 // Parameters for verifying TFGW deployment
 @[params]
 pub struct VerifyTfgwArgs {

--- a/lib/k8_apps/core/k8app.v
+++ b/lib/k8_apps/core/k8app.v
@@ -53,8 +53,8 @@ pub fn k8app(args_ K8AppArgs)!K8App {
 	kube_client.config.namespace = args.namespace
 
 	// Generate hostname and validate it doesn't exceed TFGW limit
-	// Replace underscores with hyphens for RFC 1123 DNS compliance
-	raw_hostname := texttools.name_fix("${args.namespace}_${args.app_name}-${args.app_instance}").replace('_', '-')
+	// TFGW hostnames must be alphanumeric only (no dashes or underscores)
+	raw_hostname := texttools.name_fix("${args.app_name}${args.app_instance}").replace('_', '').replace('-', '')
 	validated_hostname := validate_hostname(raw_hostname)
 
 	mut app := K8App{
@@ -210,4 +210,46 @@ pub fn verify_deployment_ready(args VerifyDeploymentArgs) !bool {
 	}
 
 	return false
+}
+
+// Parameters for verifying pod readiness
+@[params]
+pub struct VerifyPodArgs {
+pub mut:
+	pod_name  string @[required] // name of the pod to check
+	namespace string @[required] // namespace where pod is located
+	k8s       kubernetes.KubeClient @[required]
+	retry     int = max_deployment_retries
+}
+
+// Verify pod is ready with retry logic
+// Checks if a pod exists and is in Running phase
+pub fn verify_pod_ready(args VerifyPodArgs) ! {
+	console.print_info('Verifying pod ${args.pod_name} is ready...')
+	mut k8s := args.k8s
+	mut is_ready := false
+
+	for i in 0 .. args.retry {
+		// Check if pod exists and is running
+		result := k8s.kubectl_exec(
+			command: 'get pod ${args.pod_name} -n ${args.namespace} -o jsonpath="{.status.phase}"'
+		) or {
+			console.print_info('Waiting for pod ${args.pod_name} to be created... (${i + 1}/${args.retry})')
+			time.sleep(deployment_check_interval_seconds * time.second)
+			continue
+		}
+
+		if result.success && result.stdout == 'Running' {
+			is_ready = true
+			break
+		}
+		console.print_info('Waiting for pod ${args.pod_name} to be ready... (${i + 1}/${args.retry})')
+		time.sleep(deployment_check_interval_seconds * time.second)
+	}
+
+	if !is_ready {
+		console.print_stderr('Pod ${args.pod_name} failed to become ready.')
+		return error('Pod ${args.pod_name} failed to become ready.')
+	}
+	console.print_info('Pod ${args.pod_name} is ready.')
 }

--- a/lib/k8_apps/devel/k8_gitea/gitea_actions.v
+++ b/lib/k8_apps/devel/k8_gitea/gitea_actions.v
@@ -10,10 +10,11 @@ import time
 // checks if a certain version or above is installed
 pub fn installed() !bool {
 	installer := get()!
-	mut k8s := installer.kube_client
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
 
 	// Try to get the gitea deployment
-	deployments := k8s.get_deployments(installer.namespace) or {
+	deployments := k8s.get_deployments(k8app.namespace) or {
 		// If we can't get deployments, it's not running
 		return false
 	}
@@ -47,7 +48,8 @@ fn install() ! {
 
 	// Get installer config to access namespace
 	installer := get()!
-	mut k8s := installer.kube_client
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
 	configure()!
 
 	// 1. Check for dependencies.
@@ -64,7 +66,7 @@ fn install() ! {
 	console.print_info('Gateway YAML file applied successfully.')
 
 	// 3. Verify TFGW deployment
-	core.verify_tfgw_deployment(tfgw_name: 'gitea', namespace: installer.namespace, k8s: k8s)!
+	core.verify_tfgw_deployment(tfgw_name: 'gitea', namespace: k8app.namespace, k8s: k8s)!
 
 	// 4. Apply PostgreSQL YAML if postgres is selected
 	if installer.db_type == 'postgres' {
@@ -75,8 +77,8 @@ fn install() ! {
 		}
 		console.print_info('PostgreSQL YAML file applied successfully.')
 
-		// Verify PostgreSQL pod is ready
-		verify_postgres_pod(namespace: installer.namespace)!
+		// Verify PostgreSQL pod is ready using core function
+		core.verify_pod_ready(pod_name: installer.db_host, namespace: k8app.namespace, k8s: k8s)!
 	}
 
 	// 5. Apply Gitea App YAML
@@ -107,48 +109,10 @@ fn install() ! {
 	}
 }
 
-// params for verifying postgres pod is ready
-@[params]
-struct VerifyPostgresPod {
-pub mut:
-	namespace string // namespace name for postgres pod
-}
-
-// Function for verifying postgres pod is ready
-fn verify_postgres_pod(args VerifyPostgresPod) ! {
-	console.print_info('Verifying PostgreSQL pod is ready...')
-	installer := get()!
-	mut k8s := installer.kube_client
-	mut is_ready := false
-
-	for i in 0 .. core.max_deployment_retries {
-		// Check if postgres pod exists and is running
-		result := k8s.kubectl_exec(
-			command: 'get pod ${installer.db_host} -n ${args.namespace} -o jsonpath="{.status.phase}"'
-		) or {
-			console.print_info('Waiting for PostgreSQL pod to be created... (${i + 1}/${core.max_deployment_retries})')
-			time.sleep(core.deployment_check_interval_seconds * time.second)
-			continue
-		}
-
-		if result.success && result.stdout == 'Running' {
-			is_ready = true
-			break
-		}
-		console.print_info('Waiting for PostgreSQL pod to be ready... (${i + 1}/${core.max_deployment_retries})')
-		time.sleep(core.deployment_check_interval_seconds * time.second)
-	}
-
-	if !is_ready {
-		console.print_stderr('PostgreSQL pod failed to become ready.')
-		return error('PostgreSQL pod failed to become ready.')
-	}
-	console.print_info('PostgreSQL pod is ready.')
-}
-
 fn destroy() ! {
 	installer := get()!
-	mut k8s := installer.kube_client
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
 	
-	core.destroy_namespace(mut k8s, installer.namespace)!
+	core.destroy_namespace(mut k8s, k8app.namespace)!
 }

--- a/lib/k8_apps/devel/k8_gitea/gitea_model.v
+++ b/lib/k8_apps/devel/k8_gitea/gitea_model.v
@@ -2,7 +2,6 @@ module k8_gitea
 
 import incubaid.herolib.ui.console
 import incubaid.herolib.data.encoderhero
-import incubaid.herolib.virt.kubernetes
 import incubaid.herolib.core.pathlib
 import incubaid.herolib.k8_apps.core
 import strings
@@ -53,7 +52,8 @@ pub mut:
 	gitea_app_path string = '/tmp/gitea/gitea.yaml'
 	tfgw_path      string = '/tmp/gitea/tfgw-gitea.yaml'
 	postgres_path  string = '/tmp/gitea/postgres.yaml'
-	kube_client    kubernetes.KubeClient @[skip]
+	// K8App instance for kubernetes operations
+	k8app ?core.K8App @[skip]
 }
 
 // your checking & initialization code if needed
@@ -64,23 +64,27 @@ fn obj_init(mycfg_ GiteaK8SInstaller) !GiteaK8SInstaller {
 		mycfg.name = 'gitea'
 	}
 
-	// Replace the dashes, dots, and underscores with nothing
-	mycfg.name = mycfg.name.replace('_', '')
-	mycfg.name = mycfg.name.replace('-', '')
-	mycfg.name = mycfg.name.replace('.', '')
+	// Use core name_fix for consistent name handling
+	mycfg.name = core.name_fix(mycfg.name)
 
 	if mycfg.namespace == '' {
-		mycfg.namespace = '${mycfg.name}-gitea-namespace'
+		mycfg.namespace = '${mycfg.name}giteans'
 	}
 
-	if mycfg.namespace.contains('_') || mycfg.namespace.contains('.') {
-		console.print_stderr('namespace cannot contain _, was: ${mycfg.namespace}, use dashes instead.')
-		return error('namespace cannot contain _, was: ${mycfg.namespace}')
+	// Apply name_fix to namespace for consistency with k8app
+	mycfg.namespace = core.name_fix(mycfg.namespace)
+
+	if mycfg.namespace.contains('.') {
+		console.print_stderr('namespace cannot contain ., was: ${mycfg.namespace}')
+		return error('namespace cannot contain ., was: ${mycfg.namespace}')
 	}
 
 	if mycfg.hostname == '' {
 		mycfg.hostname = '${mycfg.name}giteaapp'
 	}
+
+	// Validate hostname doesn't exceed TFGW limit
+	mycfg.hostname = core.validate_hostname(mycfg.hostname)
 
 	// Validate database type
 	if mycfg.db_type !in ['sqlite3', 'postgres'] {
@@ -88,15 +92,22 @@ fn obj_init(mycfg_ GiteaK8SInstaller) !GiteaK8SInstaller {
 		return error('Unsupported database type: ${mycfg.db_type}. Only sqlite3 and postgres are supported.')
 	}
 
-	mycfg.kube_client = kubernetes.get(create: true)!
-	mycfg.kube_client.config.namespace = mycfg.namespace
+	// Initialize K8App for kubernetes operations
+	mycfg.k8app = core.k8app(
+		app_name: 'gitea'
+		app_instance: mycfg.name
+		namespace: mycfg.namespace
+	)!
 	return mycfg
 }
 
 // called before start if done
 fn configure() ! {
 	mut installer := get()!
-	mut k8s := installer.kube_client
+
+	// Unwrap k8app once
+	k8app := installer.k8app or { return error('k8app not initialized') }
+	mut k8s := k8app.kube_client
 
 	master_ips := core.get_master_node_ips(mut k8s)!
 	console.print_info('Master node IPs: ${master_ips}')
@@ -112,10 +123,11 @@ fn configure() ! {
 	fqdn := '${installer.hostname}.gent01.grid.tf'
 
 	// Create config_values for template generation
+	// Use k8app.namespace to ensure consistency with kubernetes client
 	mut config_values := ConfigValues{
 		hostname:             installer.hostname
 		backends:             backends_str_builder.str()
-		namespace:            installer.namespace
+		namespace:            k8app.namespace
 		root_url:             'https://${fqdn}/'
 		domain:               fqdn
 		http_port:            installer.http_port
@@ -125,7 +137,7 @@ fn configure() ! {
 		storage_size:         installer.storage_size
 		// Postgres connection details
 		// db_host is the full DNS name for Gitea to connect
-		db_host:     '${installer.db_host}.${installer.namespace}.svc.cluster.local'
+		db_host:     '${installer.db_host}.${k8app.namespace}.svc.cluster.local'
 		db_name:     installer.db_name
 		db_user:     installer.db_user
 		db_password: installer.db_password


### PR DESCRIPTION
### Description

add Stalwart installer & refactor Element Chat, Gitea, CryptPad installers

### Changes 

- Add Stalwart mail server K8s installer with templates and example script
- Update core k8app: shared helpers (verify_pod_ready, name_fix, hostname validation)
- Refactor Element Chat, Gitea, CryptPad to use core helpers and consistent namespaces
- Ensure TFGW-compatible, alphanumeric hostnames across all k8-app installers
- Verified install/destroy flows for Element Chat, Gitea, CryptPad, and Stalwart

### Related Issues

- https://github.com/incubaid/herolib/issues/195
